### PR TITLE
Issue #28: Crossref metadata resolver

### DIFF
--- a/src/citations/__init__.py
+++ b/src/citations/__init__.py
@@ -4,21 +4,23 @@ Filesystem-first citation registry and validation helpers.
 """
 
 from .crossref import (
-	CrossrefClient,
-	CrossrefClientConfig,
-	CrossrefError,
-	CrossrefNotFoundError,
-	normalize_doi,
-	resolve_crossref_doi_and_upsert,
-	resolve_crossref_doi_to_record,
+
+    CrossrefClient,
+    CrossrefClientConfig,
+    CrossrefError,
+    CrossrefNotFoundError,
+    normalize_doi,
+    resolve_crossref_doi_and_upsert,
+    resolve_crossref_doi_to_record,
 )
 
 __all__ = [
-	"CrossrefClient",
-	"CrossrefClientConfig",
-	"CrossrefError",
-	"CrossrefNotFoundError",
-	"normalize_doi",
-	"resolve_crossref_doi_and_upsert",
-	"resolve_crossref_doi_to_record",
+
+    "CrossrefClient",
+    "CrossrefClientConfig",
+    "CrossrefError",
+    "CrossrefNotFoundError",
+    "normalize_doi",
+    "resolve_crossref_doi_and_upsert",
+    "resolve_crossref_doi_to_record",
 ]

--- a/tests/test_crossref_resolver.py
+++ b/tests/test_crossref_resolver.py
@@ -13,8 +13,11 @@ import pytest
 
 from src.citations.crossref import (
     CrossrefClient,
+    CrossrefError,
     CrossrefNotFoundError,
+    CITATION_FALLBACK_YEAR,
     normalize_doi,
+    crossref_work_to_citation_record,
     resolve_crossref_doi_and_upsert,
     resolve_crossref_doi_to_record,
 )
@@ -108,3 +111,54 @@ def test_resolve_crossref_doi_not_found():
     with patch.object(httpx.Client, "get", return_value=_make_crossref_response(payload, status_code=404)):
         with pytest.raises(CrossrefNotFoundError):
             resolve_crossref_doi_to_record(doi="10.5555/notfound", citation_key="Key", client=client)
+
+
+@pytest.mark.unit
+def test_search_by_title_empty_results():
+    payload = {"message": {"items": []}}
+    client = CrossrefClient()
+
+    with patch.object(httpx.Client, "get", return_value=_make_crossref_response(payload)):
+        items = client.search_by_title(title="Some title", rows=3)
+
+    assert items == []
+
+
+@pytest.mark.unit
+def test_search_by_title_invalid_params():
+    client = CrossrefClient()
+    with pytest.raises(ValueError):
+        client.search_by_title(title="", rows=5)
+    with pytest.raises(ValueError):
+        client.search_by_title(title="t", rows=0)
+    with pytest.raises(ValueError):
+        client.search_by_title(title="t", year=999)
+
+
+@pytest.mark.unit
+def test_crossref_work_to_citation_record_fallbacks():
+    work = {
+        "DOI": "10.1000/182",
+        "title": [],
+        "author": [],
+        "issued": {"date-parts": []},
+    }
+    rec = crossref_work_to_citation_record(work=work, citation_key="Key", status="verified")
+
+    validate_citation_record(rec)
+    assert rec["title"] == "(missing title)"
+    assert rec["authors"] == ["(unknown)"]
+    assert rec["year"] == CITATION_FALLBACK_YEAR
+    assert rec["identifiers"]["doi"] == "10.1000/182"
+
+
+@pytest.mark.unit
+def test_fetch_work_by_doi_invalid_json_raises_crossref_error():
+    # Create a response with invalid JSON content so resp.json() raises ValueError.
+    request = httpx.Request("GET", "https://api.crossref.org/works/10.1000%2F182")
+    bad_json_response = httpx.Response(status_code=200, content=b"not-json", request=request)
+
+    client = CrossrefClient()
+    with patch.object(httpx.Client, "get", return_value=bad_json_response):
+        with pytest.raises(CrossrefError):
+            client.fetch_work_by_doi("10.1000/182")


### PR DESCRIPTION
Adds a minimal Crossref resolver for citation verification.

- `CrossrefClient` using `httpx` with centralized timeouts
- DOI normalization and `/works/{doi}` fetch
- Optional title search helper
- Normalization into schema-valid CitationRecord and optional registry upsert
- Unit tests with HTTP mocked

Closes #28.
