### PR TITLE
Integrate citation verification into literature workflow outputs

### DIFF
--- a/src/agents/literature_synthesis.py
+++ b/src/agents/literature_synthesis.py
@@ -449,6 +449,7 @@ Please create a comprehensive literature review summary that:
                     )
                     verified += 1
                 except Exception as e:
+                    logger.exception("Crossref resolution failed")
                     record = make_minimal_citation_record(
                         citation_key=citation_key,
                         title=title,
@@ -458,7 +459,7 @@ Please create a comprehensive literature review summary that:
                         created_at=created_at,
                         identifiers={"doi": doi},
                     )
-                    record["notes"] = f"Crossref resolution failed: {e}"
+                    record["notes"] = f"Crossref resolution failed: {type(e).__name__}"
                     error += 1
             else:
                 record = make_minimal_citation_record(

--- a/tests/test_literature_agents.py
+++ b/tests/test_literature_agents.py
@@ -262,8 +262,6 @@ class TestLiteratureSynthesisAgent:
     ):
         from src.agents.literature_synthesis import LiteratureSynthesisAgent
         from src.citations.registry import make_minimal_citation_record
-        import json
-        from pathlib import Path
 
         agent = LiteratureSynthesisAgent()
 
@@ -283,9 +281,10 @@ class TestLiteratureSynthesisAgent:
                 identifiers={"doi": doi},
             )
 
-        import src.agents.literature_synthesis as lit_synth_module
-
-        monkeypatch.setattr(lit_synth_module, "resolve_crossref_doi_to_record", _fake_resolve_crossref_doi_to_record)
+        monkeypatch.setattr(
+            "src.agents.literature_synthesis.resolve_crossref_doi_to_record",
+            _fake_resolve_crossref_doi_to_record,
+        )
 
         project_folder = str(temp_project_folder)
         result = await agent.execute(
@@ -344,8 +343,6 @@ class TestLiteratureSynthesisAgent:
         monkeypatch,
     ):
         from src.agents.literature_synthesis import LiteratureSynthesisAgent
-        import json
-        from pathlib import Path
 
         agent = LiteratureSynthesisAgent()
 
@@ -357,9 +354,10 @@ class TestLiteratureSynthesisAgent:
         def _boom(*args, **kwargs):
             raise RuntimeError("Crossref down")
 
-        import src.agents.literature_synthesis as lit_synth_module
-
-        monkeypatch.setattr(lit_synth_module, "resolve_crossref_doi_to_record", _boom)
+        monkeypatch.setattr(
+            "src.agents.literature_synthesis.resolve_crossref_doi_to_record",
+            _boom,
+        )
 
         project_folder = str(temp_project_folder)
         result = await agent.execute(


### PR DESCRIPTION
Closes #31

## Summary
- Literature synthesis now writes canonical bibliography artifacts: bibliography/citations.json and bibliography/references.bib
- Root references.bib remains for compatibility, sourced from the canonical BibTeX
- citations_data.json now includes bibliography verification metadata (counts and status)
- Literature review includes a provisional-citations note when verification is incomplete

## Tests
- pytest tests/test_literature_agents.py
- pytest tests/test_bibliography_builder.py
