### PR TITLE
Docs: update roadmap and plan Sprint 3

### DIFF
--- a/docs/next_steps.md
+++ b/docs/next_steps.md
@@ -14,6 +14,8 @@ The system can currently plan and scaffold. The missing pieces are the ones that
 
 ## 1. Source ingestion and evidence ledger (not only PDFs)
 
+Status (2025-12-23): Sprint 1 evidence ledger is implemented (issues #6 through #11). The core per-source layout, parsing to location-indexed text, evidence extraction, and evidence gates exist. Remaining work is mainly around improving coverage and expanding parsers beyond MVP paths.
+
 ### Why this is blocking
 Without a durable evidence layer, the system will sound plausible while being hard to audit. Reviewers tend to punish vagueness: claims like “X finds…” with no traceable support, and empirical claims with no reproducible artifacts.
 
@@ -48,6 +50,8 @@ Without a durable evidence layer, the system will sound plausible while being ha
 - Output contains no “X finds…” style claims without a corresponding evidence item.
 
 ## 2. Citation system and verification layer (metadata correctness + claim checking)
+
+Status (2025-12-23): Sprint 2 citation infrastructure is implemented (issues #27 through #31). Canonical bibliography artifacts (`bibliography/citations.json`, `bibliography/references.bib`), Crossref metadata verification, and an optional citation linting gate exist. Remaining work is the claim to evidence alignment check (citation accuracy verification against EvidenceItems).
 
 ### Why this is blocking
 Incorrect citations are an easy reason to reject a manuscript. This is true across disciplines and article types.
@@ -188,13 +192,19 @@ These changes reduce “looks good but is wrong” outputs.
 - Add parsing to location-indexed text.
 - Require evidence items before synthesis and before “Related Work” writing.
 
+Status: completed (issues #6 through #11).
+
 ### Sprint 2: Citations and bibliography correctness
 - Add DOI and metadata verification and canonical BibTeX.
 - Add citation linting gate.
 
+Status: completed (issues #27 through #31).
+
 ### Sprint 3: Computation outputs + claims registry
 - Add analysis runner agent and export of LaTeX tables and figures.
 - Add claims registry and enforce writer use.
+
+Status: next.
 
 ### Sprint 4: Writing + adversarial review
 - Add section writers.

--- a/docs/sprint_2_checklist.md
+++ b/docs/sprint_2_checklist.md
@@ -1,0 +1,42 @@
+# Sprint 2 Checklist: Citations and Bibliography Correctness
+
+Goal: add a filesystem-first citation system that produces canonical bibliography artifacts, verifies metadata when possible, and provides gates so downstream writing can block or downgrade language when citations are missing or unverified.
+
+## Outcomes
+- A project has a stable bibliography folder layout.
+- Citation metadata is stored in a canonical registry (`bibliography/citations.json`) that is schema-validated.
+- Canonical BibTeX is produced deterministically (`bibliography/references.bib`).
+- Crossref verification can upgrade records to verified metadata.
+- A citation linting gate can block or downgrade when citations are missing or unverified.
+- The literature workflow Phase 2 writes canonical bibliography artifacts and avoids definitive citation claims when verification is incomplete.
+
+## Scope (Sprint 2)
+From the roadmap section “Sprint 2: Citations and bibliography correctness” in [docs/next_steps.md](next_steps.md).
+
+- `CitationRecord` schema and validation
+- Citation registry (`bibliography/citations.json`)
+- Crossref resolver (DOI and basic bibliographic lookup)
+- Deterministic bibliography builder (`bibliography/references.bib`)
+- Citation linting gate (opt-in)
+- Literature workflow Phase 2 integration (best-effort verification and canonical outputs)
+
+Out of scope for Sprint 2
+- Claim to evidence alignment checks (citation accuracy verification against EvidenceItems)
+- Computation outputs and metrics registry (Sprint 3)
+
+## Definition of Done
+Sprint 2 is complete. The corresponding GitHub issues are closed:
+- #27 Add CitationRecord schema + citations registry
+- #28 Crossref metadata resolver
+- #29 Bibliography builder (references.bib + citations.json)
+- #30 Citation linter gate
+- #31 Integrate citation verification into literature workflow outputs
+
+## Verification plan
+- Run unit tests: `pytest -m unit`
+- Run full suite: `pytest`
+- Manual smoke test
+  - Run literature workflow on a sample project
+  - Confirm bibliography artifacts appear under `bibliography/`
+  - Confirm `references.bib` at project root stays compatible (if present)
+  - Confirm downgrade messaging appears when verification is incomplete

--- a/docs/sprint_2_issue_stubs.md
+++ b/docs/sprint_2_issue_stubs.md
@@ -1,0 +1,59 @@
+# Sprint 2 Issue Stubs (reference)
+
+Sprint 2 is complete; the issues below are already closed. This file exists to keep a stable copy of the Sprint 2 scope and acceptance criteria.
+
+Closed issues:
+- https://github.com/giatenica/gia-agentic-short/issues/27
+- https://github.com/giatenica/gia-agentic-short/issues/28
+- https://github.com/giatenica/gia-agentic-short/issues/29
+- https://github.com/giatenica/gia-agentic-short/issues/30
+- https://github.com/giatenica/gia-agentic-short/issues/31
+
+---
+
+## Issue 1: CitationRecord schema + registry
+Title: Sprint 2: Add CitationRecord schema + citations registry
+
+Acceptance criteria:
+- `CitationRecord` validation exists and fails on missing required fields
+- A per-project citations registry exists at `bibliography/citations.json`
+- Registry is filesystem-first and schema-validated
+
+---
+
+## Issue 2: Crossref resolver
+Title: Sprint 2: Crossref metadata resolver (DOI, title lookup)
+
+Acceptance criteria:
+- Crossref can resolve a DOI to a schema-valid CitationRecord
+- Resolver uses centralized timeouts and handles common error cases
+
+---
+
+## Issue 3: Bibliography builder
+Title: Sprint 2: Bibliography builder (references.bib + citations.json)
+
+Acceptance criteria:
+- Deterministic BibTeX written to `bibliography/references.bib`
+- Deterministic citations registry written to `bibliography/citations.json`
+- DOI-based dedupe is deterministic
+
+---
+
+## Issue 4: Citation linting gate
+Title: Sprint 2: Citation linter gate (block or downgrade on unverified citations)
+
+Acceptance criteria:
+- Gate is off by default
+- Gate can block or downgrade based on missing and unverified citation keys
+- Gate scans project writing files (Markdown, LaTeX) for citation keys
+
+---
+
+## Issue 5: Phase 2 integration
+Title: Sprint 2: Integrate citation verification into literature workflow outputs
+
+Acceptance criteria:
+- Literature synthesis writes canonical bibliography artifacts under `bibliography/`
+- If verification is incomplete, outputs avoid definitive citation claims and add a clear disclaimer
+- Unit tests mock resolver success and failure paths

--- a/docs/sprint_3_checklist.md
+++ b/docs/sprint_3_checklist.md
@@ -1,0 +1,47 @@
+# Sprint 3 Checklist: Computation Outputs and Claims Registry (MVP)
+
+Goal: add a strict computation layer that can regenerate quantitative outputs and a minimal claims registry so numeric statements and key findings are traceable to reproducible artifacts.
+
+This sprint is intentionally MVP. It should enable one end-to-end path: run a small analysis script against project data, store outputs in a standard layout, and expose a machine-readable metrics file and claims registry.
+
+## Outcomes
+- Standard analysis and outputs layout exists for a project:
+  - `analysis/` for scripts
+  - `outputs/tables/` for LaTeX tables
+  - `outputs/figures/` for figures
+  - `outputs/metrics.json` for headline numbers
+  - `outputs/artifacts.json` for run metadata and file inventory
+  - `claims/claims.json` for claim registry
+- A minimal runner can execute an analysis script in a constrained way and capture provenance.
+- A minimal schema exists for MetricRecord and ClaimRecord.
+- A workflow gate can block or downgrade when computed claims are missing required metrics.
+
+## Scope (Sprint 3)
+From the roadmap section “Sprint 3: Computation outputs + claims registry” in [docs/next_steps.md](next_steps.md).
+
+- Minimal metrics schema and validation
+- Minimal claims schema and validation
+- Standard project output layout helpers
+- MVP analysis runner (script-based)
+- MVP gate for computed claims and/or missing metrics
+
+Out of scope for Sprint 3
+- Full notebook execution support
+- Multi-step pipelines and parameter sweeps
+- Full section writers that enforce claim usage everywhere (Sprint 4)
+
+## Definition of Done
+- A project gets the standard output folders created automatically.
+- An analysis runner can execute a script and record provenance in `outputs/artifacts.json`.
+- `outputs/metrics.json` validates and can be referenced by writers.
+- `claims/claims.json` validates and can reference metrics keys.
+- A gate exists and is off by default; it blocks or downgrades when computed claims are unsupported.
+- Unit tests cover schemas, layout creation, and gate behavior.
+
+## Verification plan
+- Run unit tests: `pytest -m unit`
+- Run full suite: `pytest`
+- Manual smoke test
+  - Create a sample project with data
+  - Run the analysis runner
+  - Verify outputs are created and validate against schemas

--- a/docs/sprint_3_issue_stubs.md
+++ b/docs/sprint_3_issue_stubs.md
@@ -1,0 +1,90 @@
+# Sprint 3 Issue Stubs (copy-paste)
+
+Use these as GitHub issues. Each is PR-sized and maps to [docs/sprint_3_checklist.md](sprint_3_checklist.md).
+
+## Issue 1: Project outputs layout helpers
+Title: Sprint 3: Standardize project outputs layout (analysis, outputs, claims)
+
+Body:
+- Add helpers to create the standard output folders:
+  - `analysis/`
+  - `outputs/tables/`
+  - `outputs/figures/`
+  - `claims/`
+- Do not create any outputs by default other than empty folders.
+
+Acceptance criteria:
+- Layout creation is idempotent.
+- Unit tests cover directory creation.
+
+Labels: sprint-3, outputs
+
+---
+
+## Issue 2: MetricRecord schema + validation
+Title: Sprint 3: Add MetricRecord schema and validation
+
+Body:
+- Add `src/schemas/metric_record.schema.json`.
+- Extend `src/utils/schema_validation.py` with `validate_metric_record(...)`.
+- Add tests for pass and fail cases.
+
+Acceptance criteria:
+- Minimal valid MetricRecord passes.
+- Missing required fields fails.
+
+Labels: sprint-3, schemas
+
+---
+
+## Issue 3: ClaimRecord schema + validation
+Title: Sprint 3: Add ClaimRecord schema and validation
+
+Body:
+- Add `src/schemas/claim_record.schema.json`.
+- Extend `src/utils/schema_validation.py` with `validate_claim_record(...)`.
+- Define MVP claim types:
+  - `computed` claims must reference one or more metric keys.
+  - `source_backed` claims must reference citations and evidence ids (can be optional for MVP if evidence ids are not available yet).
+
+Acceptance criteria:
+- Minimal valid ClaimRecord passes.
+- Computed claims without metric keys fail validation.
+
+Labels: sprint-3, schemas
+
+---
+
+## Issue 4: Analysis runner MVP
+Title: Sprint 3: Add analysis runner to execute scripts and capture provenance
+
+Body:
+- Add an MVP analysis runner (script-based) under `src/analysis/` or `src/tools/`.
+- It should:
+  - Run a Python script from `analysis/`.
+  - Record run metadata and created files to `outputs/artifacts.json`.
+  - Avoid inheriting secrets where practical.
+
+Acceptance criteria:
+- Runner can execute a small sample script in tests using the temp project folder.
+- Runner writes `outputs/artifacts.json` deterministically for a fixed input.
+
+Labels: sprint-3, analysis
+
+---
+
+## Issue 5: Computation gate
+Title: Sprint 3: Add computation gate for missing metrics and claims
+
+Body:
+- Add a gate that checks:
+  - If any computed claims exist, referenced metric keys exist in `outputs/metrics.json`.
+- Gate is off by default.
+- Gate action supports block or downgrade.
+
+Acceptance criteria:
+- Gate blocks when required metrics are missing.
+- Gate passes when metrics are present.
+- Unit tests cover both paths.
+
+Labels: sprint-3, gating


### PR DESCRIPTION
## What changed
- Marked Sprint 1 and Sprint 2 as completed in docs/next_steps.md
- Added Sprint 2 checklist docs (completed)
- Added Sprint 3 checklist and PR-sized issue stubs

## Sprint 3 issues opened
- #37 Standardize project outputs layout
- #38 MetricRecord schema and validation
- #39 ClaimRecord schema and validation
- #40 Analysis runner with provenance capture
- #41 Computation gate for missing metrics

## Tests
- pytest tests/test_schema_validation.py
- pytest tests/test_registry.py
