### PR TITLE
Sprint 3: Standardize project outputs layout

### DIFF
--- a/src/utils/project_layout.py
+++ b/src/utils/project_layout.py
@@ -1,8 +1,11 @@
-"""Project outputs layout helpers.
+""" 
+Project Outputs Layout
+======================
+Helpers for standardizing the on-disk outputs layout for a project.
 
-Sprint 3 establishes a standard set of folders inside each project for analysis
-artifacts and derived outputs. This module provides small helpers to resolve and
-create that layout.
+Author: Gia Tenica*
+*Gia Tenica is an anagram for Agentic AI. Gia is a fully autonomous AI researcher,
+for more information see: https://giatenica.com
 """
 
 from __future__ import annotations
@@ -61,6 +64,7 @@ def ensure_project_outputs_layout(project_folder: str | Path) -> ProjectOutputsP
     paths = project_outputs_paths(project_folder)
 
     paths.analysis_dir.mkdir(parents=True, exist_ok=True)
+    paths.outputs_dir.mkdir(parents=True, exist_ok=True)
     paths.outputs_tables_dir.mkdir(parents=True, exist_ok=True)
     paths.outputs_figures_dir.mkdir(parents=True, exist_ok=True)
     paths.claims_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/test_project_layout.py
+++ b/tests/test_project_layout.py
@@ -23,6 +23,7 @@ def test_ensure_project_outputs_layout_is_idempotent_and_empty(temp_project_fold
     assert paths_first == paths_second
 
     assert paths_first.analysis_dir.is_dir()
+    assert paths_first.outputs_dir.is_dir()
     assert paths_first.outputs_tables_dir.is_dir()
     assert paths_first.outputs_figures_dir.is_dir()
     assert paths_first.claims_dir.is_dir()


### PR DESCRIPTION
## What changed
- Added a small outputs layout helper that resolves and creates the standard project folders:
-   - analysis
-   - outputs/tables
-   - outputs/figures
-   - claims
- Layout creation is idempotent and does not create any files by default.

## Tests:- pytest tests/test_project_layout.py

Closes #37 