### PR TITLE
Sprint 5 Issue #66: Citation accuracy verification (claim ↔ evidence)

### DIFF
--- a/scripts/run_citation_accuracy_gate.py
+++ b/scripts/run_citation_accuracy_gate.py
@@ -1,0 +1,74 @@
+"""Run the citation accuracy gate on a project folder.
+
+Deterministic and offline.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run the citation accuracy gate")
+    parser.add_argument("project_folder", help="Path to a project folder")
+    parser.add_argument(
+        "--enabled",
+        action="store_true",
+        help="Enable enforcement (default: false). If false, gate is permissive.",
+    )
+    parser.add_argument(
+        "--on-failure",
+        choices=["block", "downgrade"],
+        default="block",
+        help="Behavior when checks fail (default: block)",
+    )
+    parser.add_argument("--min-alignment-score", type=float, default=0.18)
+    parser.add_argument("--min-keyword-overlap", type=float, default=0.06)
+    parser.add_argument("--enable-entity-overlap", action="store_true")
+    parser.add_argument("--min-entity-overlap", type=float, default=0.20)
+    parser.add_argument("--enable-numeric-consistency", action="store_true")
+    parser.add_argument("--max-evidence-items-per-claim", type=int, default=5)
+
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[1]
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+
+    from src.citations.accuracy_gate import (
+        CitationAccuracyGateConfig,
+        CitationAccuracyGateError,
+        enforce_citation_accuracy_gate,
+    )
+
+    cfg = CitationAccuracyGateConfig(
+        enabled=bool(args.enabled),
+        on_failure=args.on_failure,
+        min_alignment_score=max(0.0, min(1.0, float(args.min_alignment_score))),
+        min_keyword_overlap=max(0.0, min(1.0, float(args.min_keyword_overlap))),
+        enable_entity_overlap=bool(args.enable_entity_overlap),
+        min_entity_overlap=max(0.0, min(1.0, float(args.min_entity_overlap))),
+        enable_numeric_consistency=bool(args.enable_numeric_consistency),
+        max_evidence_items_per_claim=max(1, int(args.max_evidence_items_per_claim)),
+    )
+
+    try:
+        result = enforce_citation_accuracy_gate(project_folder=args.project_folder, config=cfg)
+    except CitationAccuracyGateError as e:
+        print(str(e))
+        return 2
+
+    print(f"project_folder: {args.project_folder}")
+    print(f"enabled: {result.get('enabled')}")
+    print(f"action: {result.get('action')}")
+    print(f"checked_claims_total: {result.get('checked_claims_total')}")
+    print(f"failed_claims_total: {result.get('failed_claims_total')}")
+    print(f"skipped_missing_evidence_total: {result.get('skipped_missing_evidence_total')}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/citations/__init__.py
+++ b/src/citations/__init__.py
@@ -30,6 +30,13 @@ from .gates import (
     find_referenced_citation_keys,
 )
 
+from .accuracy_gate import (
+    CitationAccuracyGateConfig,
+    CitationAccuracyGateError,
+    check_citation_accuracy_gate,
+    enforce_citation_accuracy_gate,
+)
+
 __all__ = [
     "CrossrefClient",
     "CrossrefClientConfig",
@@ -51,4 +58,9 @@ __all__ = [
     "check_citation_gate",
     "enforce_citation_gate",
     "find_referenced_citation_keys",
+
+    "CitationAccuracyGateConfig",
+    "CitationAccuracyGateError",
+    "check_citation_accuracy_gate",
+    "enforce_citation_accuracy_gate",
 ]

--- a/src/citations/accuracy_gate.py
+++ b/src/citations/accuracy_gate.py
@@ -1,0 +1,545 @@
+"""Citation accuracy verification.
+
+Deterministic, filesystem-first gate that checks whether source-backed claim
+statements align with their referenced evidence excerpts.
+
+This is a lightweight early-warning system. It does not attempt full
+fact-checking.
+
+Design constraints:
+- No LLM calls.
+- Avoid persisting evidence excerpts into logs.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Literal, Mapping, Optional, Sequence, Set, Tuple
+
+from loguru import logger
+
+from src.tracing import safe_set_current_span_attributes
+from src.utils.schema_validation import is_valid_claim_record, is_valid_evidence_item
+from src.utils.validation import validate_project_folder
+
+
+class CitationAccuracyGateError(ValueError):
+    """Raised when the citation accuracy gate blocks execution."""
+
+
+OnFailureAction = Literal["block", "downgrade"]
+
+
+_STOPWORDS: Set[str] = {
+    "a",
+    "an",
+    "and",
+    "are",
+    "as",
+    "at",
+    "be",
+    "by",
+    "for",
+    "from",
+    "has",
+    "have",
+    "in",
+    "is",
+    "it",
+    "its",
+    "of",
+    "on",
+    "or",
+    "that",
+    "the",
+    "this",
+    "to",
+    "was",
+    "were",
+    "with",
+}
+
+
+@dataclass(frozen=True)
+class CitationAccuracyGateConfig:
+    """Configuration for citation accuracy verification."""
+
+    enabled: bool = False
+    on_failure: OnFailureAction = "block"
+
+    min_alignment_score: float = 0.18
+    min_keyword_overlap: float = 0.06
+
+    enable_entity_overlap: bool = False
+    min_entity_overlap: float = 0.20
+
+    enable_numeric_consistency: bool = False
+
+    max_evidence_items_per_claim: int = 5
+
+    @classmethod
+    def from_context(cls, context: Dict[str, Any]) -> "CitationAccuracyGateConfig":
+        raw = context.get("citation_accuracy_gate")
+        if not isinstance(raw, dict):
+            return cls()
+
+        enabled = bool(raw.get("enabled", False))
+        on_failure = raw.get("on_failure", "block")
+        if on_failure not in ("block", "downgrade"):
+            on_failure = "block"
+
+        def _as_float(val: Any, default: float) -> float:
+            try:
+                return float(val)
+            except (TypeError, ValueError):
+                return default
+
+        def _as_int(val: Any, default: int) -> int:
+            try:
+                return int(val)
+            except (TypeError, ValueError):
+                return default
+
+        min_alignment_score = _as_float(raw.get("min_alignment_score", cls.min_alignment_score), cls.min_alignment_score)
+        min_keyword_overlap = _as_float(raw.get("min_keyword_overlap", cls.min_keyword_overlap), cls.min_keyword_overlap)
+        enable_entity_overlap = bool(raw.get("enable_entity_overlap", cls.enable_entity_overlap))
+        min_entity_overlap = _as_float(raw.get("min_entity_overlap", cls.min_entity_overlap), cls.min_entity_overlap)
+        enable_numeric_consistency = bool(raw.get("enable_numeric_consistency", cls.enable_numeric_consistency))
+        max_evidence_items_per_claim = _as_int(raw.get("max_evidence_items_per_claim", cls.max_evidence_items_per_claim), cls.max_evidence_items_per_claim)
+
+        # Clamp ranges.
+        min_alignment_score = min(1.0, max(0.0, min_alignment_score))
+        min_keyword_overlap = min(1.0, max(0.0, min_keyword_overlap))
+        min_entity_overlap = min(1.0, max(0.0, min_entity_overlap))
+        if max_evidence_items_per_claim < 1:
+            max_evidence_items_per_claim = 1
+
+        return cls(
+            enabled=enabled,
+            on_failure=on_failure,
+            min_alignment_score=min_alignment_score,
+            min_keyword_overlap=min_keyword_overlap,
+            enable_entity_overlap=enable_entity_overlap,
+            min_entity_overlap=min_entity_overlap,
+            enable_numeric_consistency=enable_numeric_consistency,
+            max_evidence_items_per_claim=max_evidence_items_per_claim,
+        )
+
+
+def _load_json_list(path: Path) -> Tuple[List[Any], Optional[str]]:
+    if not path.exists():
+        return [], None
+
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            payload = json.load(f)
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError) as e:
+        return [], f"{type(e).__name__}"
+
+    if not isinstance(payload, list):
+        return [], "not_a_list"
+
+    return payload, None
+
+
+def _tokenize(text: str) -> Set[str]:
+    tokens: set[str] = set()
+    for raw in re.findall(r"[A-Za-z0-9]+", text.lower()):
+        if len(raw) < 3:
+            continue
+        if raw.isdigit():
+            # Keep numbers out of keyword overlap; they are handled separately.
+            continue
+        if raw in _STOPWORDS:
+            continue
+        tokens.add(raw)
+    return tokens
+
+
+def _extract_named_entities(text: str) -> Set[str]:
+    # Heuristic: capture capitalized words and all-caps tokens.
+    ents: set[str] = set()
+    for m in re.findall(r"\b(?:[A-Z][a-zA-Z]{2,}|[A-Z]{2,})\b", text):
+        ents.add(m.lower())
+    return ents
+
+
+def _extract_numbers(text: str) -> Set[str]:
+    # Capture integers, decimals, and percents.
+    nums: set[str] = set()
+    for m in re.findall(r"\b\d+(?:\.\d+)?%?\b", text):
+        nums.add(m)
+    return nums
+
+
+def _filter_year_like_numbers(nums: Set[str]) -> Set[str]:
+    """Remove year-like integers (1900-2100) so they do not dominate numeric checks."""
+
+    out: set[str] = set()
+    for n in nums:
+        if n.endswith("%"):
+            out.add(n)
+            continue
+
+        if n.isdigit() and len(n) == 4:
+            try:
+                iv = int(n)
+            except ValueError:
+                out.add(n)
+                continue
+            if 1900 <= iv <= 2100:
+                continue
+
+        out.add(n)
+    return out
+
+
+def _jaccard(a: Set[str], b: Set[str]) -> float:
+    if not a and not b:
+        return 1.0
+    if not a or not b:
+        return 0.0
+    inter = len(a & b)
+    union = len(a | b)
+    return inter / union if union else 0.0
+
+
+class CitationAccuracyVerifier:
+    """Score alignment between claim statement and evidence excerpts."""
+
+    def __init__(self, config: CitationAccuracyGateConfig):
+        self._cfg = config
+
+    def verify_claim(self, claim: Mapping[str, Any], evidence_items: Sequence[Mapping[str, Any]]) -> Dict[str, Any]:
+        claim_id = str(claim.get("claim_id") or "").strip()
+        statement = str(claim.get("statement") or "").strip()
+
+        evidence_ids = claim.get("evidence_ids")
+        evidence_ids_list: List[str] = []
+        if isinstance(evidence_ids, list):
+            evidence_ids_list = [str(x) for x in evidence_ids if isinstance(x, str) and x.strip()]
+
+        citation_keys = claim.get("citation_keys")
+        citation_keys_list: List[str] = []
+        if isinstance(citation_keys, list):
+            citation_keys_list = [str(x) for x in citation_keys if isinstance(x, str) and x.strip()]
+
+        combined: List[str] = []
+        used_ids: List[str] = []
+        for item in evidence_items[: self._cfg.max_evidence_items_per_claim]:
+            ev_id = item.get("evidence_id")
+            if isinstance(ev_id, str) and ev_id.strip():
+                used_ids.append(ev_id.strip())
+            excerpt = item.get("excerpt")
+            if isinstance(excerpt, str) and excerpt.strip():
+                combined.append(excerpt)
+            context = item.get("context")
+            if isinstance(context, str) and context.strip():
+                combined.append(context)
+
+        evidence_text = "\n".join(combined)
+
+        reasons: List[str] = []
+
+        claim_tokens = _tokenize(statement)
+        evidence_tokens = _tokenize(evidence_text)
+        keyword_overlap = _jaccard(claim_tokens, evidence_tokens)
+
+        entity_overlap = 0.0
+        if self._cfg.enable_entity_overlap:
+            claim_ents = _extract_named_entities(statement)
+            evidence_ents = _extract_named_entities(evidence_text)
+            entity_overlap = _jaccard(claim_ents, evidence_ents)
+
+        numeric_ok = True
+        if self._cfg.enable_numeric_consistency:
+            claim_nums = _filter_year_like_numbers(_extract_numbers(statement))
+            evidence_nums = _filter_year_like_numbers(_extract_numbers(evidence_text))
+            if claim_nums and not claim_nums.issubset(evidence_nums):
+                numeric_ok = False
+
+        alignment_score = float(keyword_overlap)
+        if self._cfg.enable_entity_overlap:
+            alignment_score = min(1.0, alignment_score + 0.20 * float(entity_overlap))
+
+        if self._cfg.enable_numeric_consistency and not numeric_ok:
+            alignment_score = max(0.0, alignment_score * 0.50)
+
+        ok = True
+
+        if keyword_overlap < self._cfg.min_keyword_overlap:
+            ok = False
+            reasons.append("keyword_overlap_below_threshold")
+
+        if self._cfg.enable_entity_overlap and entity_overlap < self._cfg.min_entity_overlap:
+            ok = False
+            reasons.append("entity_overlap_below_threshold")
+
+        if self._cfg.enable_numeric_consistency and not numeric_ok:
+            ok = False
+            reasons.append("numeric_mismatch")
+
+        if alignment_score < self._cfg.min_alignment_score:
+            ok = False
+            reasons.append("alignment_score_below_threshold")
+
+        return {
+            "claim_id": claim_id,
+            "citation_keys": citation_keys_list,
+            "evidence_ids": evidence_ids_list,
+            "evidence_ids_used": used_ids,
+            "checked": True,
+            "ok": ok,
+            "reasons": reasons,
+            "alignment_score": round(alignment_score, 6),
+            "keyword_overlap": round(keyword_overlap, 6),
+            "entity_overlap": round(entity_overlap, 6),
+            "numeric_ok": numeric_ok,
+        }
+
+
+def _iter_evidence_files(project_folder: Path) -> Iterable[Path]:
+    sources_dir = project_folder / "sources"
+    if not sources_dir.exists():
+        return []
+    return sorted(sources_dir.glob("*/evidence.json"))
+
+
+def _load_evidence_map(project_folder: Path) -> Tuple[Dict[str, Dict[str, Any]], int, int]:
+    """Return (by_evidence_id, invalid_items, evidence_files_scanned)."""
+
+    by_id: Dict[str, Dict[str, Any]] = {}
+    invalid = 0
+    scanned = 0
+
+    for evidence_path in _iter_evidence_files(project_folder):
+        if not evidence_path.is_file():
+            continue
+
+        scanned += 1
+        payload, err = _load_json_list(evidence_path)
+        if err:
+            logger.debug(f"Citation accuracy gate: evidence read error: {evidence_path}: {err}")
+            continue
+
+        for item in payload:
+            if not isinstance(item, dict) or not is_valid_evidence_item(item):
+                invalid += 1
+                continue
+
+            evidence_id = item.get("evidence_id")
+            if isinstance(evidence_id, str) and evidence_id.strip():
+                by_id[evidence_id.strip()] = item
+
+    return by_id, invalid, scanned
+
+
+def _load_source_backed_claims(project_folder: Path) -> Tuple[List[Dict[str, Any]], int, bool, Optional[str]]:
+    claims_path = project_folder / "claims" / "claims.json"
+    payload, err = _load_json_list(claims_path)
+
+    invalid = 0
+    claims: List[Dict[str, Any]] = []
+
+    for item in payload:
+        if not isinstance(item, dict) or not is_valid_claim_record(item):
+            invalid += 1
+            continue
+
+        if str(item.get("kind")) != "source_backed":
+            continue
+
+        claims.append(item)
+
+    return claims, invalid, claims_path.exists(), err
+
+
+def check_citation_accuracy_gate(
+    *,
+    project_folder: str | Path,
+    config: Optional[CitationAccuracyGateConfig] = None,
+) -> Dict[str, Any]:
+    """Check claim statement alignment against evidence excerpts.
+
+    Expected locations:
+    - claims/claims.json: list[ClaimRecord]
+    - sources/*/evidence.json: list[EvidenceItem]
+
+    Returns a dict with keys:
+    - ok (bool)
+    - enabled (bool)
+    - action (pass|block|downgrade|disabled)
+    - reports (list)
+    - checked_claims_total (int)
+    - failed_claims_total (int)
+    - skipped_missing_evidence_total (int)
+    - claims_file_present (bool)
+    - claims_read_error (str|None)
+    - claims_invalid_items (int)
+    - evidence_invalid_items (int)
+    - evidence_files_scanned (int)
+    """
+
+    cfg = config or CitationAccuracyGateConfig()
+    pf = validate_project_folder(project_folder)
+
+    if not cfg.enabled:
+        result = {
+            "ok": True,
+            "enabled": False,
+            "action": "disabled",
+            "reports": [],
+            "checked_claims_total": 0,
+            "failed_claims_total": 0,
+            "skipped_missing_evidence_total": 0,
+            "claims_file_present": (pf / "claims" / "claims.json").exists(),
+            "claims_read_error": None,
+            "claims_invalid_items": 0,
+            "evidence_invalid_items": 0,
+            "evidence_files_scanned": 0,
+        }
+
+        safe_set_current_span_attributes(
+            {
+                "gate.name": "citation_accuracy",
+                "gate.enabled": False,
+                "gate.ok": True,
+                "gate.action": "disabled",
+            }
+        )
+
+        return result
+
+    claims, claims_invalid, claims_file_present, claims_read_error = _load_source_backed_claims(pf)
+    evidence_map, evidence_invalid, evidence_files_scanned = _load_evidence_map(pf)
+
+    verifier = CitationAccuracyVerifier(cfg)
+
+    reports: List[Dict[str, Any]] = []
+    checked = 0
+    failed = 0
+    skipped_missing = 0
+
+    for claim in claims:
+        evidence_ids = claim.get("evidence_ids")
+        evidence_ids_list: List[str] = []
+        if isinstance(evidence_ids, list):
+            evidence_ids_list = [str(x) for x in evidence_ids if isinstance(x, str) and x.strip()]
+
+        if not evidence_ids_list:
+            skipped_missing += 1
+            reports.append(
+                {
+                    "claim_id": str(claim.get("claim_id") or "").strip(),
+                    "citation_keys": claim.get("citation_keys") if isinstance(claim.get("citation_keys"), list) else [],
+                    "evidence_ids": [],
+                    "evidence_ids_used": [],
+                    "checked": False,
+                    "ok": True,
+                    "reasons": ["missing_evidence_ids"],
+                    "alignment_score": 0.0,
+                    "keyword_overlap": 0.0,
+                    "entity_overlap": 0.0,
+                    "numeric_ok": True,
+                }
+            )
+            continue
+
+        evidence_items: List[Dict[str, Any]] = []
+        missing_any = False
+        for ev_id in evidence_ids_list:
+            item = evidence_map.get(ev_id)
+            if item is None:
+                missing_any = True
+                continue
+            evidence_items.append(item)
+
+        if missing_any or not evidence_items:
+            skipped_missing += 1
+            reports.append(
+                {
+                    "claim_id": str(claim.get("claim_id") or "").strip(),
+                    "citation_keys": claim.get("citation_keys") if isinstance(claim.get("citation_keys"), list) else [],
+                    "evidence_ids": evidence_ids_list,
+                    "evidence_ids_used": [i.get("evidence_id") for i in evidence_items if isinstance(i.get("evidence_id"), str)],
+                    "checked": False,
+                    "ok": True,
+                    "reasons": ["evidence_ids_unresolved"],
+                    "alignment_score": 0.0,
+                    "keyword_overlap": 0.0,
+                    "entity_overlap": 0.0,
+                    "numeric_ok": True,
+                }
+            )
+            continue
+
+        rep = verifier.verify_claim(claim, evidence_items)
+        reports.append(rep)
+        checked += 1
+        if rep.get("ok") is False:
+            failed += 1
+
+    has_problem = failed > 0
+
+    action: Literal["pass", "block", "downgrade"] = "pass"
+    ok = True
+
+    if has_problem:
+        if cfg.on_failure == "block":
+            action = "block"
+            ok = False
+        else:
+            action = "downgrade"
+
+    result = {
+        "ok": ok,
+        "enabled": True,
+        "action": action,
+        "reports": reports,
+        "checked_claims_total": checked,
+        "failed_claims_total": failed,
+        "skipped_missing_evidence_total": skipped_missing,
+        "claims_file_present": claims_file_present,
+        "claims_read_error": claims_read_error,
+        "claims_invalid_items": claims_invalid,
+        "evidence_invalid_items": evidence_invalid,
+        "evidence_files_scanned": evidence_files_scanned,
+    }
+
+    safe_set_current_span_attributes(
+        {
+            "gate.name": "citation_accuracy",
+            "gate.enabled": True,
+            "gate.ok": bool(ok),
+            "gate.action": str(action),
+            "citation_accuracy.checked_claims_total": int(checked),
+            "citation_accuracy.failed_claims_total": int(failed),
+            "citation_accuracy.skipped_missing_evidence_total": int(skipped_missing),
+            "citation_accuracy.min_alignment_score": float(cfg.min_alignment_score),
+            "citation_accuracy.min_keyword_overlap": float(cfg.min_keyword_overlap),
+            "citation_accuracy.enable_entity_overlap": bool(cfg.enable_entity_overlap),
+            "citation_accuracy.enable_numeric_consistency": bool(cfg.enable_numeric_consistency),
+        }
+    )
+
+    return result
+
+
+def enforce_citation_accuracy_gate(
+    *,
+    project_folder: str | Path,
+    config: Optional[CitationAccuracyGateConfig] = None,
+) -> Dict[str, Any]:
+    """Enforce the citation accuracy gate.
+
+    Raises:
+        CitationAccuracyGateError: if the gate is enabled and action=block.
+    """
+
+    result = check_citation_accuracy_gate(project_folder=project_folder, config=config)
+    if result.get("enabled") and result.get("action") == "block":
+        raise CitationAccuracyGateError(f"Citation accuracy gate blocked: {result}")
+    return result

--- a/tests/test_citation_accuracy_gate.py
+++ b/tests/test_citation_accuracy_gate.py
@@ -1,0 +1,226 @@
+import json
+
+import pytest
+
+from src.citations.accuracy_gate import (
+    CitationAccuracyGateConfig,
+    CitationAccuracyGateError,
+    check_citation_accuracy_gate,
+    enforce_citation_accuracy_gate,
+)
+from src.evidence.store import EvidenceStore
+
+
+def _write_claims(project_folder, claims):
+    (project_folder / "claims").mkdir(exist_ok=True)
+    (project_folder / "claims" / "claims.json").write_text(
+        json.dumps(claims, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _minimal_evidence_item(*, evidence_id: str, source_id: str, excerpt: str, context: str | None = None):
+    item = {
+        "schema_version": "1.0",
+        "evidence_id": evidence_id,
+        "source_id": source_id,
+        "kind": "quote",
+        "locator": {"type": "file", "value": "dummy.txt", "span": {"start_line": 1, "end_line": 1}},
+        "excerpt": excerpt,
+        "created_at": "2025-01-01T00:00:00Z",
+        "parser": {"name": "mvp"},
+    }
+    if context is not None:
+        item["context"] = context
+    return item
+
+
+@pytest.mark.unit
+def test_citation_accuracy_gate_aligned_claim_passes(temp_project_folder):
+    store = EvidenceStore(str(temp_project_folder))
+    store.write_evidence_items(
+        "source1",
+        [
+            _minimal_evidence_item(
+                evidence_id="ev1",
+                source_id="source1",
+                excerpt="In 2020, the inflation rate increased to 5 percent.",
+            )
+        ],
+    )
+
+    _write_claims(
+        temp_project_folder,
+        [
+            {
+                "schema_version": "1.0",
+                "claim_id": "c1",
+                "kind": "source_backed",
+                "statement": "The inflation rate increased in 2020 to 5 percent.",
+                "citation_keys": ["smith2020"],
+                "evidence_ids": ["ev1"],
+                "created_at": "2025-01-01T00:00:00Z",
+            }
+        ],
+    )
+
+    cfg = CitationAccuracyGateConfig(
+        enabled=True,
+        on_failure="block",
+        min_alignment_score=0.10,
+        min_keyword_overlap=0.05,
+        enable_numeric_consistency=True,
+    )
+
+    result = check_citation_accuracy_gate(project_folder=str(temp_project_folder), config=cfg)
+    assert result["ok"] is True
+    assert result["action"] == "pass"
+    assert result["checked_claims_total"] == 1
+    assert result["failed_claims_total"] == 0
+    assert result["reports"][0]["ok"] is True
+    assert result["reports"][0]["alignment_score"] > 0
+
+
+@pytest.mark.unit
+def test_citation_accuracy_gate_misaligned_claim_downgrades(temp_project_folder):
+    store = EvidenceStore(str(temp_project_folder))
+    store.write_evidence_items(
+        "source1",
+        [
+            _minimal_evidence_item(
+                evidence_id="ev1",
+                source_id="source1",
+                excerpt="GDP increased to 5 percent in 2020.",
+            )
+        ],
+    )
+
+    _write_claims(
+        temp_project_folder,
+        [
+            {
+                "schema_version": "1.0",
+                "claim_id": "c1",
+                "kind": "source_backed",
+                "statement": "Inflation decreased to 1 percent in 2020.",
+                "citation_keys": ["smith2020"],
+                "evidence_ids": ["ev1"],
+                "created_at": "2025-01-01T00:00:00Z",
+            }
+        ],
+    )
+
+    cfg = CitationAccuracyGateConfig(
+        enabled=True,
+        on_failure="downgrade",
+        min_alignment_score=0.25,
+        min_keyword_overlap=0.15,
+        enable_numeric_consistency=True,
+    )
+
+    result = check_citation_accuracy_gate(project_folder=str(temp_project_folder), config=cfg)
+    assert result["ok"] is True
+    assert result["action"] == "downgrade"
+    assert result["checked_claims_total"] == 1
+    assert result["failed_claims_total"] == 1
+
+    rep = result["reports"][0]
+    assert rep["checked"] is True
+    assert rep["ok"] is False
+    assert rep["reasons"]
+
+
+@pytest.mark.unit
+def test_citation_accuracy_gate_blocks_when_configured(temp_project_folder):
+    store = EvidenceStore(str(temp_project_folder))
+    store.write_evidence_items(
+        "source1",
+        [
+            _minimal_evidence_item(
+                evidence_id="ev1",
+                source_id="source1",
+                excerpt="GDP increased to 5 percent in 2020.",
+            )
+        ],
+    )
+
+    _write_claims(
+        temp_project_folder,
+        [
+            {
+                "schema_version": "1.0",
+                "claim_id": "c1",
+                "kind": "source_backed",
+                "statement": "Inflation decreased to 1 percent in 2020.",
+                "citation_keys": ["smith2020"],
+                "evidence_ids": ["ev1"],
+                "created_at": "2025-01-01T00:00:00Z",
+            }
+        ],
+    )
+
+    cfg = CitationAccuracyGateConfig(
+        enabled=True,
+        on_failure="block",
+        min_alignment_score=0.25,
+        min_keyword_overlap=0.15,
+        enable_numeric_consistency=True,
+    )
+
+    with pytest.raises(CitationAccuracyGateError):
+        enforce_citation_accuracy_gate(project_folder=str(temp_project_folder), config=cfg)
+
+
+@pytest.mark.unit
+def test_citation_accuracy_gate_missing_evidence_ids_is_graceful(temp_project_folder):
+    _write_claims(
+        temp_project_folder,
+        [
+            {
+                "schema_version": "1.0",
+                "claim_id": "c1",
+                "kind": "source_backed",
+                "statement": "Some statement.",
+                "citation_keys": ["smith2020"],
+                "evidence_ids": ["missing"],
+                "created_at": "2025-01-01T00:00:00Z",
+            }
+        ],
+    )
+
+    cfg = CitationAccuracyGateConfig(enabled=True, on_failure="block")
+    result = enforce_citation_accuracy_gate(project_folder=str(temp_project_folder), config=cfg)
+    assert result["action"] == "pass"
+    assert result["checked_claims_total"] == 0
+    assert result["skipped_missing_evidence_total"] == 1
+
+
+@pytest.mark.unit
+def test_citation_accuracy_gate_config_from_context_parses_and_sanitizes_values():
+    cfg = CitationAccuracyGateConfig.from_context(
+        {
+            "citation_accuracy_gate": {
+                "enabled": True,
+                "on_failure": "downgrade",
+                "min_alignment_score": "0.4",
+                "min_keyword_overlap": "0.2",
+                "enable_entity_overlap": True,
+                "min_entity_overlap": 2,  # will clamp to 1.0
+                "enable_numeric_consistency": True,
+                "max_evidence_items_per_claim": "2",
+            }
+        }
+    )
+
+    assert cfg.enabled is True
+    assert cfg.on_failure == "downgrade"
+    assert 0.0 <= cfg.min_alignment_score <= 1.0
+    assert 0.0 <= cfg.min_keyword_overlap <= 1.0
+    assert cfg.enable_entity_overlap is True
+    assert cfg.min_entity_overlap == 1.0
+    assert cfg.enable_numeric_consistency is True
+    assert cfg.max_evidence_items_per_claim == 2
+
+    bad = CitationAccuracyGateConfig.from_context({"citation_accuracy_gate": {"enabled": True, "on_failure": "nope"}})
+    assert bad.enabled is True
+    assert bad.on_failure == "block"


### PR DESCRIPTION
Closes #66.

What changed:
- Added deterministic citation accuracy verifier and gate that scores claim statement alignment against evidence excerpts.
- Handles missing evidence IDs gracefully by skipping checks (delegated to id-based gate).
- Integrates as an optional pre-writing stage in writing_review.
- Adds CLI runner script.

Testing:
- pytest tests/test_citation_accuracy_gate.py tests/test_writing_review_integration.py