### PR TITLE
Fix Crossref volume/issue/pages mapping

### DIFF
--- a/src/citations/crossref.py
+++ b/src/citations/crossref.py
@@ -220,6 +220,28 @@ def _extract_year(work: Dict[str, Any]) -> Optional[int]:
     return None
 
 
+def _coerce_scalar_str(value: Any) -> Optional[str]:
+    if isinstance(value, str):
+        s = value.strip()
+        return s or None
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, float) and value.is_integer():
+        return str(int(value))
+    return None
+
+
+def _extract_issue(work: Dict[str, Any]) -> Optional[str]:
+    direct = _coerce_scalar_str(work.get("issue"))
+    if direct:
+        return direct
+
+    journal_issue = work.get("journal-issue")
+    if isinstance(journal_issue, dict):
+        return _coerce_scalar_str(journal_issue.get("issue"))
+    return None
+
+
 def crossref_work_to_citation_record(
     *,
     work: Dict[str, Any],
@@ -250,6 +272,18 @@ def crossref_work_to_citation_record(
     venue = _pick_first_str(work.get("container-title"))
     if venue:
         record["venue"] = venue
+
+    volume = _coerce_scalar_str(work.get("volume"))
+    if volume:
+        record["volume"] = volume
+
+    issue = _extract_issue(work)
+    if issue:
+        record["issue"] = issue
+
+    pages = _coerce_scalar_str(work.get("page"))
+    if pages:
+        record["pages"] = pages
 
     publisher = work.get("publisher")
     if isinstance(publisher, str) and publisher.strip():

--- a/tests/test_crossref_resolver.py
+++ b/tests/test_crossref_resolver.py
@@ -56,6 +56,9 @@ def test_resolve_crossref_doi_to_record_minimal_fields():
             "author": [{"given": "A", "family": "One"}],
             "issued": {"date-parts": [[2020, 1, 1]]},
             "container-title": ["Journal"],
+            "volume": "12",
+            "issue": "3",
+            "page": "123-145",
             "publisher": "Pub",
             "URL": "https://example.com/paper",
         }
@@ -71,9 +74,33 @@ def test_resolve_crossref_doi_to_record_minimal_fields():
     assert rec["title"] == "A Paper"
     assert rec["year"] == 2020
     assert rec["venue"] == "Journal"
+    assert rec["volume"] == "12"
+    assert rec["issue"] == "3"
+    assert rec["pages"] == "123-145"
     assert rec["publisher"] == "Pub"
     assert rec["url"] == "https://example.com/paper"
     assert rec["identifiers"]["doi"] == "10.1000/182"
+
+
+@pytest.mark.unit
+def test_crossref_work_to_citation_record_issue_falls_back_to_journal_issue():
+    work = {
+        "DOI": "10.1000/182",
+        "title": ["A Paper"],
+        "author": [{"given": "A", "family": "One"}],
+        "issued": {"date-parts": [[2020, 1, 1]]},
+        "container-title": ["Journal"],
+        "volume": 7,
+        "journal-issue": {"issue": 2},
+        "page": "e10-e20",
+    }
+
+    rec = crossref_work_to_citation_record(work=work, citation_key="Key2020", status="verified")
+    validate_citation_record(rec)
+
+    assert rec["volume"] == "7"
+    assert rec["issue"] == "2"
+    assert rec["pages"] == "e10-e20"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Closes #81.

- Map Crossref volume, issue (with journal-issue.issue fallback), and page into CitationRecord volume, issue, pages.
- Add unit tests covering direct fields and the journal-issue fallback.