### PR TITLE
Parse PDFs with page-number locators

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,3 +29,6 @@ pytest-asyncio>=1.0.0
 # JSON schema validation (Evidence Ledger MVP)
 jsonschema>=4.23.0
 
+# PDF parsing (Sprint 1 literature ingest)
+pypdf>=4.0.0
+

--- a/src/evidence/pdf_parser.py
+++ b/src/evidence/pdf_parser.py
@@ -1,0 +1,93 @@
+"""PDF parsing for the evidence pipeline.
+
+This module parses a PDF stored under `sources/<source_id>/raw/` into a
+`parsed.json` payload with page-indexed spans.
+
+Design goals:
+- Pure-Python parsing via `pypdf`
+- Deterministic output for the same PDF input (within library stability limits)
+- No network access
+
+Author: Gia Tenica*
+*Gia Tenica is an anagram for Agentic AI. Gia is a fully autonomous AI researcher,
+for more information see: https://giatenica.com
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from pypdf import PdfReader
+
+from src.evidence.parser import MVPLineBlockParser
+
+
+@dataclass(frozen=True)
+class PdfParseResult:
+    parsed_payload: Dict[str, Any]
+    page_count: int
+
+
+def parse_pdf_to_parsed_payload(pdf_path: Path) -> PdfParseResult:
+    """Parse a PDF into a parsed payload compatible with `extract_evidence_items`.
+
+    The returned payload is a dict with:
+    - blocks: list of {kind, span, text}
+      where span includes start_page/end_page and start_line/end_line
+    - parser_name, parser_version
+    - page_count
+
+    Notes:
+    - Line numbers are global across the entire PDF (monotonic) and are primarily
+      intended for stable ordering.
+    - Page numbers are 1-based.
+    """
+    if not isinstance(pdf_path, Path):
+        raise ValueError("pdf_path must be a Path")
+    if not pdf_path.exists() or not pdf_path.is_file():
+        raise FileNotFoundError(f"PDF not found: {pdf_path}")
+
+    reader = PdfReader(str(pdf_path))
+    parser = MVPLineBlockParser()
+
+    blocks: List[Dict[str, Any]] = []
+
+    global_line_offset = 1
+    page_count = len(reader.pages)
+
+    for page_idx, page in enumerate(reader.pages, start=1):
+        page_text = page.extract_text() or ""
+        page_text = page_text.replace("\r\n", "\n").replace("\r", "\n")
+
+        parsed = parser.parse(page_text)
+
+        for b in parsed.blocks:
+            start_line = global_line_offset + b.span.start_line - 1
+            end_line = global_line_offset + b.span.end_line - 1
+            blocks.append(
+                {
+                    "kind": b.kind,
+                    "span": {
+                        "start_page": page_idx,
+                        "end_page": page_idx,
+                        "start_line": start_line,
+                        "end_line": end_line,
+                    },
+                    "text": b.text,
+                }
+            )
+
+        page_lines = page_text.splitlines()
+        # Ensure monotonic line offsets even for empty pages.
+        global_line_offset += max(len(page_lines), 1)
+
+    payload: Dict[str, Any] = {
+        "blocks": blocks,
+        "parser_name": "pypdf_page_parser",
+        "parser_version": "mvp-1",
+        "page_count": page_count,
+    }
+
+    return PdfParseResult(parsed_payload=payload, page_count=page_count)

--- a/src/schemas/evidence_item.schema.json
+++ b/src/schemas/evidence_item.schema.json
@@ -58,6 +58,8 @@
           "properties": {
             "start_line": { "type": "integer", "minimum": 1 },
             "end_line": { "type": "integer", "minimum": 1 },
+            "start_page": { "type": "integer", "minimum": 1 },
+            "end_page": { "type": "integer", "minimum": 1 },
             "start_char": { "type": "integer", "minimum": 0 },
             "end_char": { "type": "integer", "minimum": 0 }
           }

--- a/src/utils/schema_validation.py
+++ b/src/utils/schema_validation.py
@@ -100,6 +100,11 @@ def _validate_evidence_item_span_ordering(item: Dict[str, Any]) -> None:
     if isinstance(start_line, int) and isinstance(end_line, int) and end_line < start_line:
         raise ValueError("Validation failed at 'locator/span': end_line must be >= start_line")
 
+    start_page = span.get("start_page")
+    end_page = span.get("end_page")
+    if isinstance(start_page, int) and isinstance(end_page, int) and end_page < start_page:
+        raise ValueError("Validation failed at 'locator/span': end_page must be >= start_page")
+
     start_char = span.get("start_char")
     end_char = span.get("end_char")
     if isinstance(start_char, int) and isinstance(end_char, int) and end_char < start_char:

--- a/tests/test_pdf_pipeline.py
+++ b/tests/test_pdf_pipeline.py
@@ -1,0 +1,167 @@
+"""Tests for PDF parsing with page locators.
+
+Author: Gia Tenica*
+*Gia Tenica is an anagram for Agentic AI. Gia is a fully autonomous AI researcher,
+for more information see: https://giatenica.com
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from src.evidence.pipeline import run_pdf_evidence_pipeline_for_source
+from src.evidence.store import EvidenceStore
+from src.utils.schema_validation import validate_evidence_item
+
+
+def _escape_pdf_text(text: str) -> str:
+    return (
+        text.replace("\\", "\\\\")
+        .replace("(", "\\(")
+        .replace(")", "\\)")
+        .replace("\n", " ")
+    )
+
+
+def _build_synthetic_pdf(page_texts: list[str]) -> bytes:
+    """Build a small PDF with N pages and simple text.
+
+    This is a deterministic fixture generator for unit tests.
+    """
+
+    header = b"%PDF-1.4\n%\xe2\xe3\xcf\xd3\n"
+
+    n_pages = len(page_texts)
+    if n_pages < 1:
+        raise ValueError("need at least one page")
+
+    catalog_id = 1
+    pages_id = 2
+    first_page_id = 3
+    first_content_id = first_page_id + n_pages
+    font_id = first_content_id + n_pages
+
+    objects: list[bytes] = []
+
+    # 1: Catalog
+    objects.append(f"{catalog_id} 0 obj\n<< /Type /Catalog /Pages {pages_id} 0 R >>\nendobj\n".encode("utf-8"))
+
+    # 2: Pages
+    kids = " ".join(f"{first_page_id + i} 0 R" for i in range(n_pages))
+    objects.append(
+        f"{pages_id} 0 obj\n<< /Type /Pages /Kids [ {kids} ] /Count {n_pages} >>\nendobj\n".encode("utf-8")
+    )
+
+    # Page + content objects
+    for i, text in enumerate(page_texts):
+        page_id = first_page_id + i
+        content_id = first_content_id + i
+
+        page_obj = (
+            f"{page_id} 0 obj\n"
+            f"<< /Type /Page /Parent {pages_id} 0 R /MediaBox [0 0 612 792] "
+            f"/Resources << /Font << /F1 {font_id} 0 R >> >> "
+            f"/Contents {content_id} 0 R >>\n"
+            f"endobj\n"
+        ).encode("utf-8")
+        objects.append(page_obj)
+
+        escaped = _escape_pdf_text(text)
+        stream = f"BT /F1 12 Tf 72 720 Td ({escaped}) Tj ET\n".encode("utf-8")
+        content_obj = (
+            f"{content_id} 0 obj\n<< /Length {len(stream)} >>\nstream\n".encode("utf-8")
+            + stream
+            + b"endstream\nendobj\n"
+        )
+        objects.append(content_obj)
+
+    # Font
+    objects.append(
+        f"{font_id} 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n".encode("utf-8")
+    )
+
+    # Assemble with xref
+    offsets: list[int] = [0]
+    body = bytearray()
+    body.extend(header)
+
+    for obj in objects:
+        offsets.append(len(body))
+        body.extend(obj)
+
+    xref_offset = len(body)
+    size = len(offsets)
+
+    body.extend(f"xref\n0 {size}\n".encode("utf-8"))
+    body.extend(b"0000000000 65535 f \n")
+    for off in offsets[1:]:
+        body.extend(f"{off:010d} 00000 n \n".encode("utf-8"))
+
+    body.extend(
+        (
+            f"trailer\n<< /Size {size} /Root {catalog_id} 0 R >>\n"
+            f"startxref\n{xref_offset}\n%%EOF\n"
+        ).encode("utf-8")
+    )
+
+    return bytes(body)
+
+
+@pytest.mark.unit
+def test_pdf_pipeline_writes_parsed_with_page_locators_and_evidence_items(temp_project_folder):
+    store = EvidenceStore(str(temp_project_folder))
+    source_id = "src_pdf"
+    sp = store.ensure_source_layout(source_id)
+
+    pdf_bytes = _build_synthetic_pdf(
+        [
+            "Table 1: Summary statistics for the sample. This is long enough.",
+            "Figure 2: Another caption-like line with 42% in it.",
+        ]
+    )
+
+    raw_pdf_path = sp.raw_dir / "paper.pdf"
+    raw_pdf_path.write_bytes(pdf_bytes)
+
+    summary = run_pdf_evidence_pipeline_for_source(
+        project_folder=str(temp_project_folder),
+        source_id=source_id,
+        raw_pdf_filename="paper.pdf",
+        max_items=25,
+        created_at="2025-01-01T00:00:00+00:00",
+    )
+
+    assert summary["source_id"] == source_id
+    assert summary["parsed_blocks_count"] > 0
+
+    parsed = store.read_parsed(source_id)
+    assert isinstance(parsed, dict)
+    blocks = parsed.get("blocks")
+    assert isinstance(blocks, list)
+    assert blocks
+
+    # parsed.json blocks must include page locators.
+    assert any(
+        isinstance(b, dict)
+        and isinstance(b.get("span"), dict)
+        and b["span"].get("start_page") == 1
+        and b["span"].get("end_page") == 1
+        for b in blocks
+    )
+
+    items = store.read_evidence_items(source_id, validate=True)
+    assert isinstance(items, list)
+    assert items
+
+    # At least one EvidenceItem must carry a page locator.
+    assert any(
+        isinstance(i.get("locator"), dict)
+        and isinstance(i["locator"].get("span"), dict)
+        and isinstance(i["locator"]["span"].get("start_page"), int)
+        for i in items
+    )
+
+    for item in items:
+        validate_evidence_item(item)


### PR DESCRIPTION
Implements issue #78. Adds pypdf-based PDF parsing for sources/<source_id>/raw/*.pdf, writes parsed.json with page spans, extends EvidenceItem span schema to include start_page/end_page, and updates extractor to propagate page locators into evidence items. Includes a synthetic PDF fixture test.