### PR TITLE
Issue #109: Review-to-revision loop

### DIFF
--- a/src/agents/writing_review_integration.py
+++ b/src/agents/writing_review_integration.py
@@ -96,9 +96,19 @@ def _infer_target_relpaths_from_review(
     review_structured: Dict[str, Any],
     source_citation_map: Dict[str, str],
 ) -> List[str]:
-    """Infer which section relpaths should be rewritten based on referee checklist.
+    """Infer which section relpaths should be rewritten based on the structured referee checklist.
 
-    Best-effort: if inference fails, default to rewriting all reviewed sections.
+    This function inspects ``review_structured["checklist"]`` (if present) and uses a
+    best-effort heuristic to decide which of the reviewed sections should be
+    rewritten.
+
+    The inference currently considers:
+    - Missing sections (``check == "sections_exist"``)
+    - Unknown or unverified citation keys (``citations_known_keys``, ``citations_verified``)
+    - Evidence-coverage issues translated via ``source_citation_map`` (``evidence_coverage``)
+
+    If specific targets cannot be inferred, the function falls back to returning a
+    copy of ``review_relpaths``.
     """
 
     targets: Set[str] = set()

--- a/tests/test_writing_review_revision_loop.py
+++ b/tests/test_writing_review_revision_loop.py
@@ -1,4 +1,5 @@
 import json
+import os
 from pathlib import Path
 from unittest.mock import patch
 
@@ -19,6 +20,7 @@ class _StubAgent:
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+@patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}, clear=True)
 async def test_revision_loop_reruns_only_targeted_sections(tmp_path: Path):
     # Minimal project structure expected by the writing stage
     project_folder = tmp_path
@@ -44,7 +46,7 @@ async def test_revision_loop_reruns_only_targeted_sections(tmp_path: Path):
         state["intro_runs"] += 1
         out = project_folder / intro_rel
         out.parent.mkdir(parents=True, exist_ok=True)
-        out.write_text("Intro text\\n", encoding="utf-8")
+        out.write_text(r"Intro text\n", encoding="utf-8")
         return AgentResult(
             agent_name="intro",
             task_type=TaskType.DOCUMENT_CREATION,
@@ -59,7 +61,7 @@ async def test_revision_loop_reruns_only_targeted_sections(tmp_path: Path):
         out = project_folder / methods_rel
         out.parent.mkdir(parents=True, exist_ok=True)
         # Put an unknown citation key so the referee can target this section
-        out.write_text("Methods text\\n\\cite{BadKey}\\n", encoding="utf-8")
+        out.write_text(r"Methods text\n\cite{BadKey}\n", encoding="utf-8")
         return AgentResult(
             agent_name="methods",
             task_type=TaskType.DOCUMENT_CREATION,
@@ -140,6 +142,7 @@ async def test_revision_loop_reruns_only_targeted_sections(tmp_path: Path):
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+@patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}, clear=True)
 async def test_revision_loop_respects_max_iterations_and_removes_files(tmp_path: Path):
     project_folder = tmp_path
     (project_folder / "project.json").write_text("{}\n", encoding="utf-8")
@@ -154,7 +157,7 @@ async def test_revision_loop_respects_max_iterations_and_removes_files(tmp_path:
     def intro_execute(ctx):
         out = project_folder / intro_rel
         out.parent.mkdir(parents=True, exist_ok=True)
-        out.write_text("Intro text\\n", encoding="utf-8")
+        out.write_text(r"Intro text\n", encoding="utf-8")
         return AgentResult(
             agent_name="intro",
             task_type=TaskType.DOCUMENT_CREATION,


### PR DESCRIPTION
Implements a bounded writing review-to-revision loop (default 3 iterations) with targeted rewrites based on referee checklist details, and persists a deterministic revision history artifact at outputs/writing_review_history.json.

Key points:
- Reruns only implicated writer outputs when review fails
- Never deletes non-writer review target files
- Adds unit tests covering targeted reruns and max-iteration cleanup

Tests:
- pytest (full suite)