### PR TITLE
Issue #118: analysis script discovery and ordered execution

### DIFF
--- a/src/agents/data_analysis_execution.py
+++ b/src/agents/data_analysis_execution.py
@@ -239,7 +239,16 @@ class DataAnalysisExecutionAgent(BaseAgent):
                 script = str(r.get("script", {}).get("path") or "")
                 result = r.get("result", {}) if isinstance(r.get("result"), dict) else {}
                 ok = bool(result.get("success"))
-                rc = int(result.get("returncode")) if isinstance(result.get("returncode"), int) else -1
+                rc_raw = result.get("returncode")
+                if isinstance(rc_raw, int):
+                    rc = rc_raw
+                elif isinstance(rc_raw, str):
+                    try:
+                        rc = int(rc_raw)
+                    except ValueError:
+                        rc = -1
+                else:
+                    rc = -1
                 created = r.get("created_files") if isinstance(r.get("created_files"), list) else []
                 run_results.append(
                     {

--- a/tests/test_analysis_discovery_and_multi_runner.py
+++ b/tests/test_analysis_discovery_and_multi_runner.py
@@ -38,6 +38,58 @@ def test_discover_analysis_scripts_uses_manifest_order(temp_project_folder):
 
 
 @pytest.mark.unit
+def test_discover_analysis_scripts_uses_manifest_dict_scripts_key(temp_project_folder):
+    analysis_dir = temp_project_folder / "analysis"
+    analysis_dir.mkdir(parents=True, exist_ok=True)
+
+    (analysis_dir / "01_first.py").write_text("print('1')\n", encoding="utf-8")
+    (analysis_dir / "02_second.py").write_text("print('2')\n", encoding="utf-8")
+
+    manifest = {"scripts": ["analysis/02_second.py", "analysis/01_first.py"]}
+    (analysis_dir / "manifest.json").write_text(json.dumps(manifest) + "\n", encoding="utf-8")
+
+    scripts = discover_analysis_scripts(project_folder=temp_project_folder)
+    assert scripts == ["analysis/02_second.py", "analysis/01_first.py"]
+
+
+@pytest.mark.unit
+def test_discover_analysis_scripts_rejects_invalid_manifest_json(temp_project_folder):
+    analysis_dir = temp_project_folder / "analysis"
+    analysis_dir.mkdir(parents=True, exist_ok=True)
+    (analysis_dir / "manifest.json").write_text("{not-json", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Invalid analysis manifest JSON"):
+        discover_analysis_scripts(project_folder=temp_project_folder)
+
+
+@pytest.mark.unit
+def test_discover_analysis_scripts_rejects_manifest_script_outside_analysis(temp_project_folder):
+    analysis_dir = temp_project_folder / "analysis"
+    analysis_dir.mkdir(parents=True, exist_ok=True)
+
+    outside = temp_project_folder / "not_analysis.py"
+    outside.write_text("print('nope')\n", encoding="utf-8")
+
+    manifest = ["not_analysis.py"]
+    (analysis_dir / "manifest.json").write_text(json.dumps(manifest) + "\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="must be under analysis/"):
+        discover_analysis_scripts(project_folder=temp_project_folder)
+
+
+@pytest.mark.unit
+def test_discover_analysis_scripts_rejects_manifest_missing_script(temp_project_folder):
+    analysis_dir = temp_project_folder / "analysis"
+    analysis_dir.mkdir(parents=True, exist_ok=True)
+
+    manifest = ["analysis/does_not_exist.py"]
+    (analysis_dir / "manifest.json").write_text(json.dumps(manifest) + "\n", encoding="utf-8")
+
+    with pytest.raises(FileNotFoundError, match="Manifest script not found"):
+        discover_analysis_scripts(project_folder=temp_project_folder)
+
+
+@pytest.mark.unit
 def test_multi_runner_writes_combined_artifacts_for_multiple_scripts(temp_project_folder):
     analysis_dir = temp_project_folder / "analysis"
     analysis_dir.mkdir(parents=True, exist_ok=True)
@@ -70,3 +122,46 @@ def test_multi_runner_writes_combined_artifacts_for_multiple_scripts(temp_projec
 
     assert "outputs/tables/a.csv" in payload["created_files"]
     assert "outputs/tables/b.csv" in payload["created_files"]
+
+
+@pytest.mark.unit
+def test_multi_runner_stop_on_failure_true_stops_early(temp_project_folder):
+    analysis_dir = temp_project_folder / "analysis"
+    analysis_dir.mkdir(parents=True, exist_ok=True)
+
+    (analysis_dir / "01_ok.py").write_text("print('ok')\n", encoding="utf-8")
+    (analysis_dir / "02_fail.py").write_text("raise SystemExit(2)\n", encoding="utf-8")
+    (analysis_dir / "03_after.py").write_text("print('after')\n", encoding="utf-8")
+
+    result = run_project_analysis_scripts(project_folder=temp_project_folder, stop_on_failure=True)
+    assert result.success is False
+
+    payload = json.loads((temp_project_folder / "outputs" / "artifacts.json").read_text(encoding="utf-8"))
+    assert [r["script"]["path"] for r in payload["runs"]] == ["analysis/01_ok.py", "analysis/02_fail.py"]
+
+
+@pytest.mark.unit
+def test_multi_runner_stop_on_failure_false_runs_all_scripts(temp_project_folder):
+    analysis_dir = temp_project_folder / "analysis"
+    analysis_dir.mkdir(parents=True, exist_ok=True)
+
+    (analysis_dir / "01_ok.py").write_text("print('ok')\n", encoding="utf-8")
+    (analysis_dir / "02_fail.py").write_text("raise SystemExit(2)\n", encoding="utf-8")
+    (analysis_dir / "03_after.py").write_text("print('after')\n", encoding="utf-8")
+
+    result = run_project_analysis_scripts(project_folder=temp_project_folder, stop_on_failure=False)
+    assert result.success is False
+
+    payload = json.loads((temp_project_folder / "outputs" / "artifacts.json").read_text(encoding="utf-8"))
+    assert [r["script"]["path"] for r in payload["runs"]] == [
+        "analysis/01_ok.py",
+        "analysis/02_fail.py",
+        "analysis/03_after.py",
+    ]
+
+
+@pytest.mark.unit
+def test_multi_runner_rejects_no_scripts(temp_project_folder):
+    (temp_project_folder / "analysis").mkdir(parents=True, exist_ok=True)
+    with pytest.raises(ValueError, match="No analysis scripts provided or discovered"):
+        run_project_analysis_scripts(project_folder=temp_project_folder, scripts=[])


### PR DESCRIPTION
Implements deterministic discovery and ordering of <project>/analysis/*.py, plus a multi-script runner that writes a combined outputs/artifacts.json with per-script runs.\n\nChanges\n- Adds discover_analysis_scripts() with optional analysis/manifest.json ordering and numeric-prefix sorting.\n- Adds run_project_analysis_scripts() to execute multiple scripts and write schema_version 1.1 artifacts with runs[].\n- Updates DataAnalysisExecutionAgent to use combined artifacts when running multiple scripts; single-script behavior unchanged.\n- Adds unit tests for discovery ordering, manifest ordering, and multi-run artifacts.\n\nCloses #118.