### PR TITLE
Issue #117: make evidence pipeline mandatory by default

### DIFF
--- a/src/pipeline/runner.py
+++ b/src/pipeline/runner.py
@@ -133,7 +133,18 @@ async def run_full_pipeline(
         return context
 
     phase2 = LiteratureWorkflow()
-    phase2_result = await phase2.run(str(pf), workflow_context=workflow_overrides)
+    merged_overrides: Optional[Dict[str, Any]]
+    if isinstance(workflow_overrides, dict):
+        merged_overrides = dict(workflow_overrides)
+    else:
+        merged_overrides = {}
+
+    # Default to enabling the offline evidence pipeline for the unified runner.
+    # Callers can still explicitly disable by passing: {"evidence_pipeline": {"enabled": False}}.
+    if "evidence_pipeline" not in merged_overrides:
+        merged_overrides["evidence_pipeline"] = {"enabled": True}
+
+    phase2_result = await phase2.run(str(pf), workflow_context=merged_overrides)
     context.record_phase_result("phase_2", phase2_result)
     context.mark_checkpoint("phase_2_complete")
 

--- a/tests/test_evidence_pipeline.py
+++ b/tests/test_evidence_pipeline.py
@@ -2,6 +2,7 @@ import json
 from unittest.mock import patch
 
 import pytest
+from pypdf import PdfWriter
 
 from src.evidence.pipeline import EvidencePipelineConfig, run_local_evidence_pipeline
 from src.evidence.store import EvidenceStore
@@ -41,3 +42,52 @@ def test_local_evidence_pipeline_writes_parsed_and_evidence(temp_project_folder)
     sp = store.source_paths(source_id)
     on_disk = json.loads(sp.evidence_path.read_text(encoding="utf-8"))
     assert isinstance(on_disk, list)
+
+
+@pytest.mark.unit
+@patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}, clear=True)
+def test_local_evidence_pipeline_writes_evidence_coverage_artifact(temp_project_folder):
+    literature_dir = temp_project_folder / "literature"
+    literature_dir.mkdir(exist_ok=True)
+    (literature_dir / "notes.md").write_text(
+        "This is a sufficiently long paragraph to extract evidence from. It includes 42%.",
+        encoding="utf-8",
+    )
+
+    cfg = EvidencePipelineConfig(enabled=True, max_sources=10, ingest_sources=True, append_to_ledger=False)
+    run_local_evidence_pipeline(project_folder=str(temp_project_folder), config=cfg)
+
+    coverage_path = temp_project_folder / "outputs" / "evidence_coverage.json"
+    assert coverage_path.exists()
+    payload = json.loads(coverage_path.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == "1.0"
+    assert isinstance(payload.get("summary"), dict)
+
+
+@pytest.mark.unit
+@patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}, clear=True)
+def test_local_evidence_pipeline_processes_pdf_sources(temp_project_folder):
+    literature_dir = temp_project_folder / "literature"
+    literature_dir.mkdir(exist_ok=True)
+
+    pdf_path = literature_dir / "paper.pdf"
+    writer = PdfWriter()
+    writer.add_blank_page(width=300, height=300)
+    with open(pdf_path, "wb") as f:
+        writer.write(f)
+
+    cfg = EvidencePipelineConfig(enabled=True, max_sources=10, ingest_sources=True, append_to_ledger=False)
+    summary = run_local_evidence_pipeline(project_folder=str(temp_project_folder), config=cfg)
+
+    assert summary["processed_count"] >= 1
+    assert len(summary["source_ids"]) >= 1
+
+    store = EvidenceStore(str(temp_project_folder))
+    pdf_source_id = summary["source_ids"][0]
+
+    parsed = store.read_parsed(pdf_source_id)
+    assert isinstance(parsed, dict)
+    assert "blocks" in parsed
+
+    evidence = store.read_evidence_items(pdf_source_id)
+    assert isinstance(evidence, list)

--- a/tests/test_unified_pipeline_evidence_default.py
+++ b/tests/test_unified_pipeline_evidence_default.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.mark.unit
+@patch("src.pipeline.runner.LiteratureWorkflow")
+@patch("src.pipeline.runner.ResearchWorkflow")
+async def test_unified_pipeline_defaults_to_enabled_evidence_pipeline(
+    mock_research_workflow, mock_literature_workflow, temp_project_folder
+):
+    # Arrange: make phase 1 and phase 2 succeed without any external calls.
+    mock_research = mock_research_workflow.return_value
+    mock_research.run = AsyncMock(return_value={"success": True})
+
+    mock_lit = mock_literature_workflow.return_value
+    mock_lit.run = AsyncMock(return_value={"success": True})
+
+    from src.pipeline.runner import run_full_pipeline
+
+    # Act
+    await run_full_pipeline(
+        str(temp_project_folder),
+        enable_gap_resolution=False,
+        enable_writing_review=False,
+        workflow_overrides=None,
+    )
+
+    # Assert: LiteratureWorkflow.run receives workflow_context with evidence_pipeline enabled.
+    _, kwargs = mock_lit.run.call_args
+    ctx = kwargs.get("workflow_context")
+    assert isinstance(ctx, dict)
+    assert ctx["evidence_pipeline"]["enabled"] is True


### PR DESCRIPTION
Closes #117\n\nChanges:\n- Local evidence pipeline now processes PDFs (writes sources/<source_id>/parsed.json and sources/<source_id>/evidence.json).\n- Writes outputs/evidence_coverage.json as a minimal coverage artifact.\n- Unified pipeline runner defaults evidence pipeline enabled unless explicitly disabled.\n- Adds unit tests for the default wiring and artifacts.