### PR TITLE
Follow-up: address Copilot PDF test comment (PR #130)

### DIFF
--- a/tests/test_evidence_pipeline.py
+++ b/tests/test_evidence_pipeline.py
@@ -88,6 +88,13 @@ def test_local_evidence_pipeline_processes_pdf_sources(temp_project_folder):
     parsed = store.read_parsed(pdf_source_id)
     assert isinstance(parsed, dict)
     assert "blocks" in parsed
+    # For PDFs, we at least expect a page_count field from the parser payload.
+    assert parsed.get("page_count") == 1
 
     evidence = store.read_evidence_items(pdf_source_id)
     assert isinstance(evidence, list)
+
+    # Ensure evidence.json is present on disk even if it is empty.
+    sp = store.source_paths(pdf_source_id)
+    on_disk = json.loads(sp.evidence_path.read_text(encoding="utf-8"))
+    assert isinstance(on_disk, list)


### PR DESCRIPTION
Follow-up to #130.\n\nCopilot pointed out the PDF test was using a blank page, which can yield 0 evidence items and make the test a weak signal. This adjusts the test to validate PDF parsing and artifact creation deterministically without relying on text extraction.\n\n- Asserts parsed payload includes page_count==1\n- Asserts evidence.json exists on disk and is a JSON list\n\nRefs: https://github.com/giatenica/gia-agentic-short/pull/130#discussion_r2649109226