### PR TITLE
Follow-up: Copilot review fixes from PR #133

### DIFF
--- a/src/pipeline/runner.py
+++ b/src/pipeline/runner.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict, Optional
 
+from loguru import logger
+
 from src.agents.gap_resolution_workflow import GapResolutionWorkflow
 from src.agents.literature_workflow import LiteratureWorkflow
 from src.agents.workflow import ResearchWorkflow
@@ -168,8 +170,8 @@ async def run_full_pipeline(
         # This is filesystem-first and safe to run even when metrics.json is absent.
         try:
             generate_claims_from_metrics(project_folder=pf)
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug(f"Claims generation failed in unified pipeline: {type(e).__name__}")
 
         writing_context = _build_writing_context(pf, extra=workflow_overrides)
         writing_result = await run_writing_review_stage(writing_context)


### PR DESCRIPTION
Follow-up to PR #133 (already merged).

Copilot notes addressed:
- Avoid silently swallowing exceptions in unified pipeline claims generation; log debug-level error.
- Deduplicate claims generation by metric_key to prevent duplicate claim_id entries when metrics.json contains duplicates (last record wins), and add unit coverage.

No issue closure; #119 is already closed.