### PR TITLE
fix(#145): Extract citations from Edison formatted_answer when structured citations empty

### DIFF
--- a/tests/test_edison_client.py
+++ b/tests/test_edison_client.py
@@ -9,12 +9,8 @@ for more information see: https://giatenica.com
 """
 
 import pytest
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import patch
 from dataclasses import dataclass
-
-import sys
-from pathlib import Path
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from src.llm.edison_client import EdisonClient, Citation, LiteratureResult, JobStatus
 


### PR DESCRIPTION
## Summary
Fixes #145: Citation registry not populated from Edison literature search results.

## Problem
Edison's PQATaskResponse often returns citations embedded in the `formatted_answer` text as a References section, but doesn't populate the structured `.citations` attribute. This caused:
- `bibliography/citations.json` to remain empty `[]`
- Section writers to produce placeholder text due to missing citations
- Quality gates to have nothing to verify

## Root Cause Analysis
The existing `EdisonClient._parse_citations()` method only looked for structured `.citations`, `.references`, or `.papers` attributes on the response object. When these were empty (which is common), no citations were extracted.

Meanwhile, Edison's actual response included a rich References section in the text like:
```
References

1. (zingales1994thevalueof pages 1-4): Luigi Zingales. The value of the voting right: a study of the milan stock exchange experience. Review of Financial Studies, 7:125-148, Jan 1994. doi:10.1093/rfs/7.1.125
```

## Solution
Enhanced `EdisonClient._parse_citations()` to:
1. First try structured citation attributes (existing behavior)
2. **NEW**: Fall back to extracting citations from `formatted_answer` text
3. Parse Edison's References section format with proper handling of:
   - Author initials with periods (e.g., "Robert C. Merton")
   - DOI, URL, year, journal metadata extraction
   - Citation deduplication by title

## Testing
- Added `tests/test_edison_client.py` with 12 unit tests
- All 509 existing unit tests pass
- Tests cover:
  - Text-based citation extraction
  - Preference for structured citations when available
  - Fallback to text when structured is empty
  - Deduplication
  - Edge cases (no References section, etc.)

## Files Changed
- `src/llm/edison_client.py` - Enhanced citation parsing with text fallback
- `tests/test_edison_client.py` - New test file for Edison client