### PR TITLE
feat: Wire source acquisition into literature workflow

### DIFF
--- a/src/agents/literature_workflow.py
+++ b/src/agents/literature_workflow.py
@@ -498,7 +498,7 @@ class LiteratureWorkflow:
                         citations_data = lit_search_data.get("citations_data", [])
                         
                         if citations_data:
-                            cfg = SourceAcquisitionConfig.from_context(source_acquisition_cfg)
+                            cfg = SourceAcquisitionConfig.from_context(context)
                             acq_result = acquire_sources_from_citations(
                                 project_folder=project_folder,
                                 citations_data=citations_data,

--- a/src/evidence/acquisition.py
+++ b/src/evidence/acquisition.py
@@ -404,7 +404,7 @@ def build_sources_list_from_citations(
     """Convert citations_data into a sources_list for source acquisition.
     
     This function extracts downloadable sources from citation metadata,
-    converting DOIs to unpaywall/sci-hub URLs and detecting arXiv links.
+    constructing DOI resolver URLs (https://doi.org/...) and detecting arXiv links.
     
     Args:
         citations_data: List of citation dicts with doi/url/title/authors fields
@@ -437,8 +437,8 @@ def build_sources_list_from_citations(
                     arxiv_id = parse_arxiv_id(url)
                     # Also compute the URL-based source_id to mark as seen
                     arxiv_url_source_id = _stable_id_from_url("htm", url)
-                except Exception:
-                    pass
+                except Exception as exc:
+                    logger.debug(f"Failed to parse arXiv ID from URL {url!r}: {exc}")
         
         # arXiv sources - highest priority, free full text
         if include_arxiv and arxiv_id:
@@ -484,11 +484,10 @@ def build_sources_list_from_citations(
                         "title": title,
                         "doi": doi,
                     })
-                    continue
+                continue  # Skip direct URL extraction when DOI is present
         
         # Direct URL sources - PDF or HTML
-        if include_direct_urls and isinstance(url, str) and url.strip():
-            url = url.strip()
+        if include_direct_urls and isinstance(url, str) and url:
             if not url.startswith("https://"):
                 continue
             

--- a/tests/test_source_acquisition.py
+++ b/tests/test_source_acquisition.py
@@ -381,6 +381,10 @@ def test_acquire_sources_from_citations_writes_sources_list(temp_project_folder)
         client=client,
     )
     
+    # Check result is successful
+    assert result["ok"] is True
+    assert len(result.get("created_source_ids", [])) == 1
+    
     # Check sources_list.json was created
     sources_list_path = temp_project_folder / "sources_list.json"
     assert sources_list_path.exists()


### PR DESCRIPTION
## Summary

This PR implements issue #150 by wiring source acquisition into the literature workflow pipeline.

## Changes

### New Functions in `src/evidence/acquisition.py`

1. **`build_sources_list_from_citations()`**
   - Converts citations_data from Edison/literature search into sources_list format
   - Extracts arXiv papers (highest priority; free full text)
   - Extracts DOI-based URLs (constructs doi.org URLs for open access lookup)
   - Extracts direct PDF/HTML URLs from citation metadata
   - Deduplicates sources by stable source_id
   - Configurable via include flags (include_arxiv, include_doi_urls, include_direct_urls)

2. **`write_sources_list()`**
   - Writes sources_list.json to project folder
   - Includes metadata (generated_at, total count)

3. **`acquire_sources_from_citations()`**
   - End-to-end integration function
   - Builds sources list → writes JSON → runs acquisition
   - Returns structured result with created_source_ids and errors

### Literature Workflow Integration

- Added Step 3.5: Source Acquisition after Literature Synthesis
- Opt-in via `context['source_acquisition']['enabled'] = True`
- Non-fatal errors; workflow continues with partial results
- Populates `sources/<source_id>/` directories for evidence pipeline
- Stores result in `context['source_acquisition_result']`

## Testing

- Added 11 new unit tests covering:
  - arXiv URL extraction
  - DOI extraction and normalization
  - Direct PDF/HTML URL extraction
  - Deduplication logic
  - Empty/invalid citation handling
  - Include flag behavior
  - File writing
  - Disabled config handling
  - End-to-end integration

All 520 unit tests pass.

## Usage

Enable source acquisition in workflow context:
```python
context = {
    'source_acquisition': {
        'enabled': True,
        'max_download_bytes': 50_000_000,  # optional
    },
    # ... other context
}
```

Closes #150