### PR TITLE
fix(pipeline): enable quality gates by default with warn mode and wire claims generation (#149, #153)

### DIFF
--- a/scripts/run_writing_review_stage.py
+++ b/scripts/run_writing_review_stage.py
@@ -30,6 +30,7 @@ load_env_file_lenient()
 
 from src.agents.writing_review_integration import run_writing_review_stage  # noqa: E402
 from src.claims.generator import generate_claims_from_metrics  # noqa: E402
+from src.pipeline.defaults import default_gate_config  # noqa: E402
 
 
 def _utc_now_iso() -> str:
@@ -104,45 +105,6 @@ def _default_writing_review_config(project_folder: Path) -> Dict[str, Any]:
     }
 
 
-def _default_gate_config() -> Dict[str, Dict[str, Any]]:
-    """Return default gate configurations.
-
-    By default, gates are enabled in 'warn' mode (downgrade on failure).
-    This ensures issues are surfaced without blocking the pipeline.
-    """
-    return {
-        "evidence_gate": {
-            "require_evidence": True,
-            "min_items_per_source": 1,
-        },
-        "citation_gate": {
-            "enabled": True,
-            "on_missing": "downgrade",
-            "on_unverified": "downgrade",
-        },
-        "computation_gate": {
-            "enabled": True,
-            "on_missing_metrics": "downgrade",
-        },
-        "claim_evidence_gate": {
-            "enabled": True,
-            "on_failure": "downgrade",
-        },
-        "literature_gate": {
-            "enabled": True,
-            "on_failure": "downgrade",
-        },
-        "analysis_gate": {
-            "enabled": True,
-            "on_failure": "downgrade",
-        },
-        "citation_accuracy_gate": {
-            "enabled": True,
-            "on_failure": "downgrade",
-        },
-    }
-
-
 def _build_context(project_folder: Path) -> Dict[str, Any]:
     ctx: Dict[str, Any] = {
         "project_folder": str(project_folder),
@@ -153,7 +115,7 @@ def _build_context(project_folder: Path) -> Dict[str, Any]:
         },
     }
     # Apply default gate configs so gates are enabled by default in warn mode.
-    ctx.update(_default_gate_config())
+    ctx.update(default_gate_config())
     return ctx
 
 

--- a/src/claims/__init__.py
+++ b/src/claims/__init__.py
@@ -14,6 +14,8 @@ from .claim_evidence_gate import (
     enforce_claim_evidence_gate,
 )
 
+from .generator import generate_claims_from_metrics
+
 __all__ = [
     "ComputationGateConfig",
     "ComputationGateError",
@@ -24,4 +26,6 @@ __all__ = [
     "ClaimEvidenceGateError",
     "check_claim_evidence_gate",
     "enforce_claim_evidence_gate",
+
+    "generate_claims_from_metrics",
 ]

--- a/src/pipeline/defaults.py
+++ b/src/pipeline/defaults.py
@@ -1,0 +1,52 @@
+"""Shared default configuration for pipeline components.
+
+This module centralizes default gate configurations to avoid duplication
+across runner.py and standalone scripts.
+
+Author: Gia Tenica*
+*Gia Tenica is an anagram for Agentic AI. Gia is a fully autonomous AI researcher,
+for more information see: https://giatenica.com
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+def default_gate_config() -> Dict[str, Dict[str, Any]]:
+    """Return default gate configurations.
+
+    By default, gates are enabled in 'warn' mode (downgrade on failure).
+    This ensures issues are surfaced without blocking the pipeline.
+    """
+    return {
+        "evidence_gate": {
+            "require_evidence": True,
+            "min_items_per_source": 1,
+        },
+        "citation_gate": {
+            "enabled": True,
+            "on_missing": "downgrade",
+            "on_unverified": "downgrade",
+        },
+        "computation_gate": {
+            "enabled": True,
+            "on_missing_metrics": "downgrade",
+        },
+        "claim_evidence_gate": {
+            "enabled": True,
+            "on_failure": "downgrade",
+        },
+        "literature_gate": {
+            "enabled": True,
+            "on_failure": "downgrade",
+        },
+        "analysis_gate": {
+            "enabled": True,
+            "on_failure": "downgrade",
+        },
+        "citation_accuracy_gate": {
+            "enabled": True,
+            "on_failure": "downgrade",
+        },
+    }

--- a/src/pipeline/runner.py
+++ b/src/pipeline/runner.py
@@ -93,6 +93,45 @@ def _default_referee_review_config(project_folder: Path) -> Dict[str, Any]:
     return {"enabled": True}
 
 
+def _default_gate_config() -> Dict[str, Dict[str, Any]]:
+    """Return default gate configurations.
+
+    By default, gates are enabled in 'warn' mode (downgrade on failure).
+    This ensures issues are surfaced without blocking the pipeline.
+    """
+    return {
+        "evidence_gate": {
+            "require_evidence": True,
+            "min_items_per_source": 1,
+        },
+        "citation_gate": {
+            "enabled": True,
+            "on_missing": "downgrade",
+            "on_unverified": "downgrade",
+        },
+        "computation_gate": {
+            "enabled": True,
+            "on_missing_metrics": "downgrade",
+        },
+        "claim_evidence_gate": {
+            "enabled": True,
+            "on_failure": "downgrade",
+        },
+        "literature_gate": {
+            "enabled": True,
+            "on_failure": "downgrade",
+        },
+        "analysis_gate": {
+            "enabled": True,
+            "on_failure": "downgrade",
+        },
+        "citation_accuracy_gate": {
+            "enabled": True,
+            "on_failure": "downgrade",
+        },
+    }
+
+
 def _build_writing_context(project_folder: Path, extra: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     ctx: Dict[str, Any] = {
         "project_folder": str(project_folder),
@@ -100,6 +139,8 @@ def _build_writing_context(project_folder: Path, extra: Optional[Dict[str, Any]]
         "writing_review": _default_writing_review_config(project_folder),
         "referee_review": _default_referee_review_config(project_folder),
     }
+    # Apply default gate configs; callers can override via extra.
+    ctx.update(_default_gate_config())
     if isinstance(extra, dict) and extra:
         ctx.update(extra)
     return ctx

--- a/src/pipeline/runner.py
+++ b/src/pipeline/runner.py
@@ -20,6 +20,7 @@ from src.agents.workflow import ResearchWorkflow
 from src.agents.writing_review_integration import run_writing_review_stage
 
 from src.pipeline.context import WorkflowContext
+from src.pipeline.defaults import default_gate_config
 from src.claims.generator import generate_claims_from_metrics
 
 from src.pipeline.degradation import (
@@ -93,45 +94,6 @@ def _default_referee_review_config(project_folder: Path) -> Dict[str, Any]:
     return {"enabled": True}
 
 
-def _default_gate_config() -> Dict[str, Dict[str, Any]]:
-    """Return default gate configurations.
-
-    By default, gates are enabled in 'warn' mode (downgrade on failure).
-    This ensures issues are surfaced without blocking the pipeline.
-    """
-    return {
-        "evidence_gate": {
-            "require_evidence": True,
-            "min_items_per_source": 1,
-        },
-        "citation_gate": {
-            "enabled": True,
-            "on_missing": "downgrade",
-            "on_unverified": "downgrade",
-        },
-        "computation_gate": {
-            "enabled": True,
-            "on_missing_metrics": "downgrade",
-        },
-        "claim_evidence_gate": {
-            "enabled": True,
-            "on_failure": "downgrade",
-        },
-        "literature_gate": {
-            "enabled": True,
-            "on_failure": "downgrade",
-        },
-        "analysis_gate": {
-            "enabled": True,
-            "on_failure": "downgrade",
-        },
-        "citation_accuracy_gate": {
-            "enabled": True,
-            "on_failure": "downgrade",
-        },
-    }
-
-
 def _build_writing_context(project_folder: Path, extra: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     ctx: Dict[str, Any] = {
         "project_folder": str(project_folder),
@@ -140,7 +102,7 @@ def _build_writing_context(project_folder: Path, extra: Optional[Dict[str, Any]]
         "referee_review": _default_referee_review_config(project_folder),
     }
     # Apply default gate configs; callers can override via extra.
-    ctx.update(_default_gate_config())
+    ctx.update(default_gate_config())
     if isinstance(extra, dict) and extra:
         ctx.update(extra)
     return ctx

--- a/tests/test_full_pipeline_runner.py
+++ b/tests/test_full_pipeline_runner.py
@@ -173,10 +173,10 @@ async def test_run_full_pipeline_passes_workflow_overrides(tmp_path):
 
 @pytest.mark.unit
 def test_default_gate_config_enables_all_gates():
-    """Test that _default_gate_config enables gates in downgrade mode."""
-    from src.pipeline.runner import _default_gate_config
+    """Test that default_gate_config enables gates in downgrade mode."""
+    from src.pipeline.defaults import default_gate_config
 
-    gates = _default_gate_config()
+    gates = default_gate_config()
 
     # All gates should be present.
     assert "evidence_gate" in gates


### PR DESCRIPTION
## Summary

Implements #149 (Quality gates disabled by default) and #153 (Claims generation not wired into pipeline).

## Changes

### Issue #149 - Enable Quality Gates by Default

Added `_default_gate_config()` function that enables all quality gates in 'warn' mode (downgrade on failure):

- `evidence_gate`: require_evidence=True, min_items_per_source=1
- `citation_gate`: enabled=True, on_missing=downgrade, on_unverified=downgrade
- `computation_gate`: enabled=True, on_missing_metrics=downgrade
- `claim_evidence_gate`: enabled=True, on_failure=downgrade
- `literature_gate`: enabled=True, on_failure=downgrade
- `analysis_gate`: enabled=True, on_failure=downgrade
- `citation_accuracy_gate`: enabled=True, on_failure=downgrade

Gates in downgrade mode surface issues in output without blocking the pipeline. Users can override to `enabled: False` or switch to `on_failure: block` for strict runs.

### Issue #153 - Wire Claims Generation

- Added `generate_claims_from_metrics()` call to `run_writing_review_stage.py` before the writing stage
- Exported `generate_claims_from_metrics` from `src/claims/__init__.py`
- Claims generation was already present in `run_full_pipeline`; this ensures standalone script also generates claims

## Testing

- Added 3 new unit tests for gate configuration and context building
- All 531 unit tests pass

Fixes #149, #153