### PR TITLE
test: add E2E integration tests for full pipeline (#154)

### DIFF
--- a/tests/test_e2e_pipeline.py
+++ b/tests/test_e2e_pipeline.py
@@ -15,7 +15,7 @@ import os
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Dict
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -162,7 +162,7 @@ class TestFullPipelineE2E:
     async def test_pipeline_produces_output_with_mock_phases(self, mock_e2e_project):
         """Pipeline should complete successfully with mocked phase implementations."""
         with (
-            patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}),
+            patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}, clear=True),
             patch("src.pipeline.runner.ResearchWorkflow") as RW,
             patch("src.pipeline.runner.LiteratureWorkflow") as LW,
             patch("src.pipeline.runner.GapResolutionWorkflow") as GW,
@@ -197,7 +197,7 @@ class TestFullPipelineE2E:
     async def test_pipeline_generates_claims_from_metrics(self, mock_e2e_project):
         """Pipeline should generate claims.json from metrics.json."""
         with (
-            patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}),
+            patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}, clear=True),
             patch("src.pipeline.runner.ResearchWorkflow") as RW,
             patch("src.pipeline.runner.LiteratureWorkflow") as LW,
             patch("src.pipeline.runner.GapResolutionWorkflow") as GW,
@@ -227,7 +227,7 @@ class TestFullPipelineE2E:
     async def test_pipeline_writes_degradation_summary(self, mock_e2e_project):
         """Pipeline should write degradation summary on completion."""
         with (
-            patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}),
+            patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}, clear=True),
             patch("src.pipeline.runner.ResearchWorkflow") as RW,
             patch("src.pipeline.runner.LiteratureWorkflow") as LW,
             patch("src.pipeline.runner.GapResolutionWorkflow") as GW,
@@ -240,7 +240,7 @@ class TestFullPipelineE2E:
 
             from src.pipeline.runner import run_full_pipeline
 
-            result = await run_full_pipeline(str(mock_e2e_project))
+            await run_full_pipeline(str(mock_e2e_project))
 
         # Verify degradation summary was written
         degradation_path = mock_e2e_project / "outputs" / "degradation_summary.json"
@@ -262,7 +262,7 @@ class TestFullPipelineE2E:
             return _mock_writing_result(success=True)
 
         with (
-            patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}),
+            patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}, clear=True),
             patch("src.pipeline.runner.ResearchWorkflow") as RW,
             patch("src.pipeline.runner.LiteratureWorkflow") as LW,
             patch("src.pipeline.runner.GapResolutionWorkflow") as GW,
@@ -295,7 +295,7 @@ class TestFullPipelineE2E:
     async def test_pipeline_skips_phases_when_disabled(self, mock_e2e_project):
         """Pipeline should skip gap resolution and writing when disabled."""
         with (
-            patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}),
+            patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}, clear=True),
             patch("src.pipeline.runner.ResearchWorkflow") as RW,
             patch("src.pipeline.runner.LiteratureWorkflow") as LW,
             patch("src.pipeline.runner.GapResolutionWorkflow") as GW,
@@ -330,7 +330,7 @@ class TestFullPipelineE2E:
     async def test_pipeline_halts_on_phase_failure(self, mock_e2e_project):
         """Pipeline should halt and not run subsequent phases on failure."""
         with (
-            patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}),
+            patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}, clear=True),
             patch("src.pipeline.runner.ResearchWorkflow") as RW,
             patch("src.pipeline.runner.LiteratureWorkflow") as LW,
             patch("src.pipeline.runner.GapResolutionWorkflow") as GW,


### PR DESCRIPTION
## Summary

Implements #154 - Add E2E integration test with mock data.

## Changes

### New Test File: `tests/test_e2e_pipeline.py`

Created comprehensive E2E integration tests that verify data flows correctly through all pipeline phases using mock data and mocked external API calls.

### Test Classes

**TestFullPipelineE2E** (6 tests):
- `test_pipeline_produces_output_with_mock_phases` - Verifies pipeline completes with all phases and records checkpoints
- `test_pipeline_generates_claims_from_metrics` - Verifies claims.json is generated from metrics.json
- `test_pipeline_writes_degradation_summary` - Verifies degradation_summary.json is written
- `test_pipeline_passes_gate_configs_to_writing_stage` - Verifies all gate configs are passed to writing stage
- `test_pipeline_skips_phases_when_disabled` - Verifies gap resolution and writing can be skipped
- `test_pipeline_halts_on_phase_failure` - Verifies pipeline halts and doesn't run subsequent phases on failure

**TestMockProjectFixture** (5 tests):
- Validates the mock project fixture has all required files
- Validates project.json is valid and parseable
- Validates evidence.json contains valid evidence items
- Validates citations.json contains valid citation records
- Validates metrics.json contains valid metric records

### Mock Project Structure

The `mock_e2e_project` fixture creates a complete project with:
- `project.json` - Required project metadata
- `analysis/mock_data.csv` - Sample data file
- `sources/source1/evidence.json` - Valid evidence items
- `bibliography/citations.json` - Valid citation records
- `outputs/metrics.json` - Valid metric records
- `claims/` - Empty claims folder

## Testing

- All 11 new tests pass
- Total: 542 unit tests passing (up from 531)
- Tests run in < 4 seconds

## Acceptance Criteria Met

- [x] Test creates minimal valid project structure
- [x] Test runs pipeline with mocked external calls
- [x] Test verifies output files are created
- [x] Test checks data flows between phases
- [x] Test runs in CI in < 60 seconds

Fixes #154